### PR TITLE
Add to_data_dict round trip tests

### DIFF
--- a/EasyReflectometry/sample/items/surfactant_layer.py
+++ b/EasyReflectometry/sample/items/surfactant_layer.py
@@ -42,14 +42,18 @@ class SurfactantLayer(MultiLayer):
         if area_per_molecule is not None:
             self.layers[0].area_per_molecule.enabled = True
             self.layers[1].area_per_molecule.enabled = True
-            self.constrain_apm = True
+            self.constrain_apm = area_per_molecule.enabled
             self.area_per_molecule = area_per_molecule
+            self.layers[0].area_per_molecule.enabled = False
+            self.layers[1].area_per_molecule.enabled = False
         self.roughness = None
         if roughness is not None:
             self.layers[0].roughness.enabled = True
             self.layers[1].roughness.enabled = True
-            self.conformal_roughness = True
+            self.conformal_roughness = roughness.enabled
             self.roughness = roughness
+            self.layers[0].roughness.enabled = False
+            self.layers[1].roughness.enabled = False
 
     # Class constructors
     @classmethod
@@ -171,6 +175,7 @@ class SurfactantLayer(MultiLayer):
             self.roughness.user_constraints['roughness2'] = roughness2
         self.roughness.user_constraints['roughness1'].enabled = x
         self.roughness.user_constraints['roughness2'].enabled = x
+        self.roughness.enabled = x
 
     def constrain_solvent_roughness(self, solvent_roughness: Parameter):
         """

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -314,3 +314,8 @@ class TestModel(unittest.TestCase):
         p = Model.default()
         assert p.__repr__(
         ) == "EasyModel:\n  scale: 1.0\n  background: 1.0e-07\n  resolution: 5.0 %\n  structure:\n    EasyStructure:\n    - EasyMultiLayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n    - EasyMultiLayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n"
+
+    def test_dict_round_trip(self):
+        p = Model.default()
+        q = Model.from_dict(p.as_dict())
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/items/test_multilayer.py
+++ b/tests/sample/items/test_multilayer.py
@@ -157,5 +157,4 @@ class TestMultiLayer(unittest.TestCase):
     def test_dict_round_trip(self):
         p = MultiLayer.default()
         q = MultiLayer.from_dict(p.as_dict())
-        assert 1 == 1 
-        # assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/items/test_repeating_multilayer.py
+++ b/tests/sample/items/test_repeating_multilayer.py
@@ -180,5 +180,4 @@ class TestRepeatingMultiLayer(unittest.TestCase):
     def test_dict_round_trip(self):
         p = RepeatingMultiLayer.default()
         q = RepeatingMultiLayer.from_dict(p.as_dict())
-        assert 1 == 1
-        # assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/items/test_surfactant_layer.py
+++ b/tests/sample/items/test_surfactant_layer.py
@@ -172,35 +172,31 @@ class TestSurfactantLayer(unittest.TestCase):
     def test_dict_round_trip(self):
         p = SurfactantLayer.default()
         q = SurfactantLayer.from_dict(p.as_dict())
-        assert 1 == 1
-        #assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()
+
 
     def test_dict_round_trip_apm(self):
         p = SurfactantLayer.default()
         p.constrain_apm = True
         q = SurfactantLayer.from_dict(p.as_dict())
-        assert 1 == 1 
-        #assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()
     
     def test_dict_round_trip_apm2(self):
         p = SurfactantLayer.default()
         p.constrain_apm = True
         p.constrain_apm = False
         q = SurfactantLayer.from_dict(p.as_dict())
-        assert 1 == 1 
-        #assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()
 
     def test_dict_round_trip_roughness(self):
         p = SurfactantLayer.default()
         p.conformal_roughness = True
         q = SurfactantLayer.from_dict(p.as_dict())
-        assert 1 == 1 
-        #assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()
 
     def test_dict_round_trip_roughness2(self):
         p = SurfactantLayer.default()
         p.conformal_roughness = True
         p.conformal_roughness = False
         q = SurfactantLayer.from_dict(p.as_dict())
-        assert 1 == 1 
-        #assert p.to_data_dict() == q.to_data_dict()
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/test_layers.py
+++ b/tests/sample/test_layers.py
@@ -77,3 +77,8 @@ class TestLayers(unittest.TestCase):
         p = Layers.default()
         assert p.__repr__(
         ) == 'EasyLayers:\n- EasyLayer:\n    material:\n      EasyMaterial:\n        sld: 4.186e-6 1 / angstrom ** 2\n        isld: 0.000e-6 1 / angstrom ** 2\n    thickness: 10.000 angstrom\n    roughness: 3.300 angstrom\n- EasyLayer:\n    material:\n      EasyMaterial:\n        sld: 4.186e-6 1 / angstrom ** 2\n        isld: 0.000e-6 1 / angstrom ** 2\n    thickness: 10.000 angstrom\n    roughness: 3.300 angstrom\n'
+
+    def test_dict_round_trip(self):
+        p = Layers.default()
+        q = Layers.from_dict(p.as_dict())
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/test_materials.py
+++ b/tests/sample/test_materials.py
@@ -49,3 +49,8 @@ class TestLayers(unittest.TestCase):
         p = Materials.default()
         assert p.__repr__(
         ) == 'EasyMaterials:\n- EasyMaterial:\n    sld: 4.186e-6 1 / angstrom ** 2\n    isld: 0.000e-6 1 / angstrom ** 2\n- EasyMaterial:\n    sld: 4.186e-6 1 / angstrom ** 2\n    isld: 0.000e-6 1 / angstrom ** 2\n'
+
+    def test_dict_round_trip(self):
+        p = Materials.default()
+        q = Materials.from_dict(p.as_dict())
+        assert p.to_data_dict() == q.to_data_dict()

--- a/tests/sample/test_structure.py
+++ b/tests/sample/test_structure.py
@@ -59,3 +59,8 @@ class TestStructure(unittest.TestCase):
         p = Structure.default()
         assert p.__repr__(
         ) == 'EasyStructure:\n- EasyMultiLayer:\n    EasyLayers:\n    - EasyLayer:\n        material:\n          EasyMaterial:\n            sld: 4.186e-6 1 / angstrom ** 2\n            isld: 0.000e-6 1 / angstrom ** 2\n        thickness: 10.000 angstrom\n        roughness: 3.300 angstrom\n    - EasyLayer:\n        material:\n          EasyMaterial:\n            sld: 4.186e-6 1 / angstrom ** 2\n            isld: 0.000e-6 1 / angstrom ** 2\n        thickness: 10.000 angstrom\n        roughness: 3.300 angstrom\n- EasyMultiLayer:\n    EasyLayers:\n    - EasyLayer:\n        material:\n          EasyMaterial:\n            sld: 4.186e-6 1 / angstrom ** 2\n            isld: 0.000e-6 1 / angstrom ** 2\n        thickness: 10.000 angstrom\n        roughness: 3.300 angstrom\n    - EasyLayer:\n        material:\n          EasyMaterial:\n            sld: 4.186e-6 1 / angstrom ** 2\n            isld: 0.000e-6 1 / angstrom ** 2\n        thickness: 10.000 angstrom\n        roughness: 3.300 angstrom\n'
+
+    def test_dict_round_trip(self):
+        p = Structure.default()
+        q = Structure.from_dict(p.as_dict())
+        assert p.to_data_dict() == q.to_data_dict()


### PR DESCRIPTION
This PR adds `to_data_dict` round trip tests. This improves the stability of these methods and helped to identify some problems in the `SurfactantLayer` class. 