### PR TITLE
Remove unnecessary `area_per_molecule` and `roughness` parameters

### DIFF
--- a/EasyReflectometry/__init__.py
+++ b/EasyReflectometry/__init__.py
@@ -1,4 +1,4 @@
 MAJOR = 0
 MINOR = 0
-MICRO = 1
+MICRO = 2
 __version__ = f'{MAJOR:d}.{MINOR:d}.{MICRO:d}'

--- a/EasyReflectometry/experiment/models.py
+++ b/EasyReflectometry/experiment/models.py
@@ -43,6 +43,22 @@ class Models(BaseCollection):
         """
         return cls(*args, name=name, interface=interface)
 
+    def add_model(self, new_model: Model):
+        """
+        Add a model to the models.
+        
+        :param new_model: New model to be added.
+        """
+        self.append(new_model)
+
+    def remove_model(self, idx: int):
+        """
+        Remove an model from the models.
+
+        :param idx: Index of the model to remove
+        """
+        del self[idx]
+
     @property
     def uid(self) -> int:
         """

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,9 @@
 .. image:: https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge
         :target: https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib
         :alt: CodeFactor
-
+.. image:: https://img.shields.io/badge/docs-built-blue
+        :target: http://docs.reflectometry.org
+        :alt: Docs
 |
 
 What is EasyReflectometry?

--- a/docs/monolayer.ipynb
+++ b/docs/monolayer.ipynb
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "area_per_molecule = 40\n",
+    "area_per_molecule = 45\n",
     "roughness = 3"
    ]
   },
@@ -311,7 +311,7 @@
     "model.scale.bounds = (0.05, 1.5)\n",
     "model.background.bounds = (4e-7, 1e-6)\n",
     "\n",
-    "dspc.area_per_molecule.bounds = (30, 60)\n",
+    "dspc.layers[0].area_per_molecule.bounds = (40, 60)\n",
     "dspc.layers[1].solvation.bounds = (0.4, 0.6)"
    ]
   },

--- a/docs/multi_contrast.ipynb
+++ b/docs/multi_contrast.ipynb
@@ -182,11 +182,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "head_thickness = 10\n",
-    "tail_thickness = 16\n",
-    "head_solvation = 0.3\n",
+    "head_thickness = 12\n",
+    "tail_thickness = 20\n",
+    "head_solvation = 0.5\n",
     "tail_solvation = 0.0\n",
-    "area_per_molecule = 43\n",
+    "area_per_molecule = 45\n",
     "roughness = 3"
    ]
   },
@@ -273,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d13d2o.layers[1].thickness.value = 9"
+    "d13d2o.layers[1].thickness.value = 10"
    ]
   },
   {
@@ -333,13 +333,13 @@
     "d13d2o_model.scale.bounds = (0.05, 1.5)\n",
     "d13d2o_model.background.bounds = (4e-8, 1e-5)\n",
     "d70d2o_model.scale.bounds = (0.05, 1.5)\n",
-    "d70d2o_model.background.bounds = (4e-8, 1e-6)\n",
+    "d70d2o_model.background.bounds = (4e-8, 1e-5)\n",
     "d83acmw_model.scale.bounds = (0.05, 1.5)\n",
-    "d83acmw_model.background.bounds = (4e-8, 1e-6)\n",
+    "d83acmw_model.background.bounds = (4e-8, 1e-5)\n",
     "\n",
-    "d13d2o.area_per_molecule.bounds = (30, 60)\n",
+    "d13d2o.layers[0].area_per_molecule.bounds = (40, 50)\n",
     "d13d2o.layers[1].solvation.bounds = (0.2, 0.6)\n",
-    "d13d2o.layers[0].thickness.bounds = (14, 20)\n",
+    "d13d2o.layers[0].thickness.bounds = (18, 24)\n",
     "d13d2o.layers[1].thickness.bounds = (8, 12)"
    ]
   },

--- a/tests/sample/items/test_surfactant_layer.py
+++ b/tests/sample/items/test_surfactant_layer.py
@@ -66,12 +66,10 @@ class TestSurfactantLayer(unittest.TestCase):
         p.constrain_apm = True
         assert p.layers[0].area_per_molecule.raw_value == 30
         assert p.layers[1].area_per_molecule.raw_value == 30
-        assert p.area_per_molecule.raw_value == 30
         assert p.constrain_apm == True
-        p.area_per_molecule.value = 40
+        p.layers[0].area_per_molecule.value = 40
         assert p.layers[0].area_per_molecule.raw_value == 40
         assert p.layers[1].area_per_molecule.raw_value == 40
-        assert p.area_per_molecule.raw_value == 40
 
     def test_conformal_roughness(self):
         p = SurfactantLayer.default()
@@ -81,12 +79,10 @@ class TestSurfactantLayer(unittest.TestCase):
         p.conformal_roughness = True
         assert p.layers[0].roughness.raw_value == 2
         assert p.layers[1].roughness.raw_value == 2
-        assert p.roughness.raw_value == 2
         assert p.conformal_roughness == True
-        p.roughness.value = 4
+        p.layers[0].roughness.value = 4
         assert p.layers[0].roughness.raw_value == 4
         assert p.layers[1].roughness.raw_value == 4
-        assert p.roughness.raw_value == 4
 
     def test_constain_solvent_roughness(self):
         p = SurfactantLayer.default()
@@ -99,13 +95,11 @@ class TestSurfactantLayer(unittest.TestCase):
         p.constrain_solvent_roughness(l.roughness)
         assert p.layers[0].roughness.raw_value == 2
         assert p.layers[1].roughness.raw_value == 2
-        assert p.roughness.raw_value == 2
         assert l.roughness.raw_value == 2
         assert p.conformal_roughness == True
-        p.roughness.value = 4
+        p.layers[0].roughness.value = 4
         assert p.layers[0].roughness.raw_value == 4
         assert p.layers[1].roughness.raw_value == 4
-        assert p.roughness.raw_value == 4
         assert l.roughness.raw_value == 4
 
     def test_dict_repr(self):
@@ -178,6 +172,7 @@ class TestSurfactantLayer(unittest.TestCase):
     def test_dict_round_trip_apm(self):
         p = SurfactantLayer.default()
         p.constrain_apm = True
+        print(p.as_dict())
         q = SurfactantLayer.from_dict(p.as_dict())
         assert p.to_data_dict() == q.to_data_dict()
     


### PR DESCRIPTION
This PR removes the `area_per_molecule` and `roughness` parameters that are present on the `SurfactantLayer` objects and replaces them with using the parameter for one of the layers making up the `SurfactantLayer` object