### PR TITLE
pin hatchling, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,13 @@ build
 # Docs
 docs/_build 
 
+# VSCode
+.vscode
+
 # Misc
 ..*
 *.log
 *.zip
 .ci/
 .idea/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<=1.18.0"]  
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Latest version of hatchling caused error when doing:
pip install . 

Pinned version to previous version that did not cause the issue 