### PR TITLE
Latest hatchling, preserve module name 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]  
+requires = ["hatchling<=1.21.0"]  
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling<=1.18.0"]  
+requires = ["hatchling"]  
 build-backend = "hatchling.build"
 
 [project]
@@ -63,6 +63,9 @@ source = ['EasyReflectometry']
 [tool.github.info]
 organization = 'easyScience'
 repo = 'EasyReflectometryLib'
+
+[tool.hatch.build.targets.wheel]
+packages = ["EasyReflectometry"]
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "easyScienceCore @ git+https://github.com/easyscience/easycore.git@failed_unit_check",
     "refnx>=0.1.15",
     "refl1d>=0.8.14",
-    "scipp>=23.12.0",
+    "scipp>=23.08.0",
     "orsopy>=0.0.4"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "easyScienceCore @ git+https://github.com/easyscience/easycore.git@failed_unit_check",
     "refnx>=0.1.15",
     "refl1d>=0.8.14",
-    "scipp==23.08.0",
+    "scipp>=23.12.0",
     "orsopy>=0.0.4"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "easyScienceCore @ git+https://github.com/easyscience/easycore.git@failed_unit_check",
     "refnx>=0.1.15",
     "refl1d>=0.8.14",
-    "scipp>=23.08.0",
+    "scipp==23.08.0",
     "orsopy>=0.0.4"
 ]
 


### PR DESCRIPTION
Upgrading to latest hatchling causes problems when the module name and the project name are not the same.

This branch allows for the module name to be `EasyReflectometry` and the project name to be `EasyReflectometryLib` 

An alternative approach is to name the module and project the same.  However, this will cause problems:
#62 

Latest version of `scipp` (23.12.0) does not seem to support python 3.8