### PR TITLE
Imposing "correct" isort as requirement for a green pipeline

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install Pandoc, EasyReflectometry and dependencies

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checkout your code repository to scan
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,7 +58,7 @@ jobs:
         tox
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         name: Pytest coverage
         env_vars: OS,PYTHON,GITHUB_ACTIONS,GITHUB_ACTION,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_HEAD_REF,GITHUB_RUN_ID,GITHUB_SHA,COVERAGE_FILE

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,6 +24,7 @@ jobs:
         if: ${{ failure() }}
         run: |
             echo "::notice::In project root run 'python.exe -m isort .' and commit changes to fix errors."
+            exit 1
   CI_Testing:
     strategy:
       max-parallel: 4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -18,7 +18,7 @@ jobs:
   CI_Code_Consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: isort/isort-action@v1
       - name: Suggestion to fix errors
         if: ${{ failure() }}
@@ -36,9 +36,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -72,9 +72,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: isort/isort-action@v1
       - name: User feedback
-        run: echo "::notice If this fails, run 'python.exe -m isort .' and commit changes"      
+        run: echo "::notice::If this fails, run 'python.exe -m isort .' and commit changes"      
 
   CI_Testing:
     strategy:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-#      - name: Install dependencies
-#        run: pip install -e '.[dev]'
-
       - uses: isort/isort-action@v1    
 
   CI_Testing:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: isort/isort-action@v1
       - name: User feedback
-        run: echo "::notice::If this fails, run 'python.exe -m isort .' and commit changes"      
+        if: ${{ failure() }}
+        run: echo "::error::Run 'python.exe -m isort .' and commit changes to fix errors."      
 
   CI_Testing:
     strategy:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,8 +22,9 @@ jobs:
       - uses: isort/isort-action@v1
       - name: User feedback
         if: ${{ failure() }}
-        run: echo "::error::Run 'python.exe -m isort .' and commit changes to fix errors."      
-
+        run: |
+            echo "::error::Run 'python.exe -m isort .' and commit changes to fix errors."
+            exit 1
   CI_Testing:
     strategy:
       max-parallel: 4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,7 +58,7 @@ jobs:
         tox
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         name: Pytest coverage
         env_vars: OS,PYTHON,GITHUB_ACTIONS,GITHUB_ACTION,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_HEAD_REF,GITHUB_RUN_ID,GITHUB_SHA,COVERAGE_FILE

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,8 +15,17 @@ name: CI using pip
 on: [push, pull_request]
 
 jobs:
-  CI_Testing:
+  CI_Code_Consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+
+      - uses: isort/isort-action@v1    
+
+  CI_Testing:
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,11 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: isort/isort-action@v1
-      - name: User feedback
+      - name: Suggestion to fix errors
         if: ${{ failure() }}
         run: |
-            echo "::error::Run 'python.exe -m isort .' and commit changes to fix errors."
-            exit 1
+            echo "::notice::In project root run 'python.exe -m isort .' and commit changes to fix errors."
   CI_Testing:
     strategy:
       max-parallel: 4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: isort/isort-action@v1    
+      - uses: isort/isort-action@v1
+      - name: User feedback
+        run: echo "::notice If this fails, run 'python.exe -m isort .' and commit changes"      
 
   CI_Testing:
     strategy:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: pip install -e '.[dev]'
+#      - name: Install dependencies
+#        run: pip install -e '.[dev]'
 
       - uses: isort/isort-action@v1    
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,9 +22,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/EasyReflectometry/calculators/bornagain.py
+++ b/EasyReflectometry/calculators/bornagain.py
@@ -1,8 +1,8 @@
 __author__ = "github.com/arm61"
 
+import bornagain as ba
 from easyCore import np
 from scipy.stats import norm
-import bornagain as ba
 
 
 class BornAgain:

--- a/EasyReflectometry/calculators/refl1d.py
+++ b/EasyReflectometry/calculators/refl1d.py
@@ -3,7 +3,10 @@ __author__ = "github.com/arm61"
 from typing import Tuple
 
 from easyCore import np
-from refl1d import names, model
+from refl1d import (
+    model,
+    names,
+)
 
 
 class Refl1d:

--- a/EasyReflectometry/calculators/refl1d.py
+++ b/EasyReflectometry/calculators/refl1d.py
@@ -4,7 +4,8 @@ from typing import Tuple
 
 from easyCore import np
 from refl1d import (
-    model, names,
+    model,
+    names,
 )
 
 

--- a/EasyReflectometry/calculators/refl1d.py
+++ b/EasyReflectometry/calculators/refl1d.py
@@ -4,8 +4,7 @@ from typing import Tuple
 
 from easyCore import np
 from refl1d import (
-    model,
-    names,
+    model, names,
 )
 
 

--- a/EasyReflectometry/data.py
+++ b/EasyReflectometry/data.py
@@ -1,9 +1,16 @@
 __author__ = 'github.com/arm61'
 
-from typing import Union, TextIO
+from typing import (
+    TextIO,
+    Union,
+)
+
 import numpy as np
 import scipp as sc
-from orsopy.fileio import orso, Header
+from orsopy.fileio import (
+    Header,
+    orso,
+)
 
 
 def load(fname: Union[TextIO, str]) -> sc.DataGroup:

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -1,15 +1,22 @@
 __author__ = 'github.com/arm61'
 
-from typing import Union
 from copy import deepcopy
+from typing import Union
 
 import yaml
 from easyCore import np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
-from EasyReflectometry.sample.structure import Structure
-from EasyReflectometry.sample.item import MultiLayer, RepeatingMultiLayer
+from easyCore.Objects.ObjectClasses import (
+    BaseObj,
+    Parameter,
+)
+
+from EasyReflectometry.sample.item import (
+    MultiLayer,
+    RepeatingMultiLayer,
+)
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
+from EasyReflectometry.sample.structure import Structure
 
 LAYER_DETAILS = {
     'scale': {

--- a/EasyReflectometry/experiment/models.py
+++ b/EasyReflectometry/experiment/models.py
@@ -4,6 +4,7 @@ from typing import List
 
 import yaml
 from easyCore.Objects.Groups import BaseCollection
+
 from EasyReflectometry.experiment.model import Model
 
 

--- a/EasyReflectometry/fitting.py
+++ b/EasyReflectometry/fitting.py
@@ -2,7 +2,6 @@ __author__ = 'github.com/arm61'
 
 import numpy as np
 import scipp as sc
-
 from easyCore.Fitting.Fitting import MultiFitter as easyFitter
 
 from EasyReflectometry.experiment.model import Model

--- a/EasyReflectometry/interface.py
+++ b/EasyReflectometry/interface.py
@@ -1,7 +1,8 @@
 __author__ = "github.com/wardsimon"
 
-from EasyReflectometry.interfaces import InterfaceTemplate
 from easyCore.Objects.Inferface import InterfaceFactoryTemplate
+
+from EasyReflectometry.interfaces import InterfaceTemplate
 
 
 class InterfaceFactory(InterfaceFactoryTemplate):

--- a/EasyReflectometry/interfaces/bornagain.py
+++ b/EasyReflectometry/interfaces/bornagain.py
@@ -1,14 +1,17 @@
 __author__ = "github.com/arm61"
 
 import numpy as np
-
 from easyCore.Objects.Inferface import ItemContainer
-from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+
 from EasyReflectometry.calculators.bornagain import BornAgain as BornAgain_calc
-from EasyReflectometry.sample.material import Material, MaterialMixture
-from EasyReflectometry.sample.layer import Layer
-from EasyReflectometry.sample.item import MultiLayer
 from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+from EasyReflectometry.sample.item import MultiLayer
+from EasyReflectometry.sample.layer import Layer
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialMixture,
+)
 
 
 class BornAgain(InterfaceTemplate):

--- a/EasyReflectometry/interfaces/interfaceTemplate.py
+++ b/EasyReflectometry/interfaces/interfaceTemplate.py
@@ -1,8 +1,11 @@
 __author__ = "github.com/wardsimon"
 
-import numpy as np
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 
+import numpy as np
 from easyCore import borg
 from easyCore.Objects.core import ComponentSerializer
 

--- a/EasyReflectometry/interfaces/refl1d.py
+++ b/EasyReflectometry/interfaces/refl1d.py
@@ -1,16 +1,23 @@
 __author__ = "github.com/arm61"
 
-from typing import List, Tuple, Union
+from typing import (
+    List,
+    Tuple,
+    Union,
+)
 
 import numpy as np
-
 from easyCore.Objects.Inferface import ItemContainer
-from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+
 from EasyReflectometry.calculators.refl1d import Refl1d as Refl1d_calc
-from EasyReflectometry.sample.material import Material, MaterialMixture
-from EasyReflectometry.sample.layer import Layer
-from EasyReflectometry.sample.item import MultiLayer
 from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+from EasyReflectometry.sample.item import MultiLayer
+from EasyReflectometry.sample.layer import Layer
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialMixture,
+)
 
 
 class Refl1d(InterfaceTemplate):

--- a/EasyReflectometry/interfaces/refnx.py
+++ b/EasyReflectometry/interfaces/refnx.py
@@ -1,16 +1,23 @@
 __author__ = "github.com/arm61"
 
-from typing import List, Tuple, Union
+from typing import (
+    List,
+    Tuple,
+    Union,
+)
 
 import numpy as np
-
 from easyCore.Objects.Inferface import ItemContainer
-from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+
 from EasyReflectometry.calculators.refnx import Refnx as Refnx_calc
-from EasyReflectometry.sample.material import Material, MaterialMixture
-from EasyReflectometry.sample.layer import Layer
-from EasyReflectometry.sample.item import MultiLayer
 from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.interfaces.interfaceTemplate import InterfaceTemplate
+from EasyReflectometry.sample.item import MultiLayer
+from EasyReflectometry.sample.layer import Layer
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialMixture,
+)
 
 
 class Refnx(InterfaceTemplate):

--- a/EasyReflectometry/measurement/data.py
+++ b/EasyReflectometry/measurement/data.py
@@ -1,6 +1,10 @@
 __author__ = 'github.com/arm61'
 
-from typing import Union, TextIO
+from typing import (
+    TextIO,
+    Union,
+)
+
 import scipp as sc
 from orsopy.fileio import orso
 

--- a/EasyReflectometry/plot.py
+++ b/EasyReflectometry/plot.py
@@ -1,7 +1,7 @@
 __author__ = 'github.com/arm61'
 
-import scipp as sc
 import matplotlib.pyplot as plt
+import scipp as sc
 from matplotlib.gridspec import GridSpec
 
 color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']

--- a/EasyReflectometry/sample/items/multilayer.py
+++ b/EasyReflectometry/sample/items/multilayer.py
@@ -1,7 +1,11 @@
-from typing import Union, List
-import yaml
+from typing import (
+    List,
+    Union,
+)
 
+import yaml
 from easyCore.Objects.ObjectClasses import BaseObj
+
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
 

--- a/EasyReflectometry/sample/items/repeating_multilayer.py
+++ b/EasyReflectometry/sample/items/repeating_multilayer.py
@@ -1,9 +1,14 @@
 from copy import deepcopy
-from typing import Union, List
+from typing import (
+    List,
+    Union,
+)
 
 from easyCore.Objects.ObjectClasses import Parameter
+
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
+
 from .multilayer import MultiLayer
 
 REPEATINGMULTILAYER_DETAILS = {

--- a/EasyReflectometry/sample/items/surfactant_layer.py
+++ b/EasyReflectometry/sample/items/surfactant_layer.py
@@ -2,9 +2,11 @@ from typing import List
 
 from easyCore.Fitting.Constraints import ObjConstraint
 from easyCore.Objects.ObjectClasses import Parameter
-from EasyReflectometry.sample.material import Material
+
 from EasyReflectometry.sample.layer import LayerApm
 from EasyReflectometry.sample.layers import Layers
+from EasyReflectometry.sample.material import Material
+
 from .multilayer import MultiLayer
 
 

--- a/EasyReflectometry/sample/layer.py
+++ b/EasyReflectometry/sample/layer.py
@@ -1,15 +1,24 @@
 __author__ = 'github.com/arm61'
 
-from typing import ClassVar
 from copy import deepcopy
+from typing import ClassVar
 
 import yaml
 from easyCore import np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Constraints import FunctionalConstraint
+from easyCore.Objects.ObjectClasses import (
+    BaseObj,
+    Parameter,
+)
 
-from EasyReflectometry.sample.material import Material, MaterialMixture
-from EasyReflectometry.special.calculations import neutron_scattering_length, apm_to_sld
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialMixture,
+)
+from EasyReflectometry.special.calculations import (
+    apm_to_sld,
+    neutron_scattering_length,
+)
 
 LAYER_DETAILS = {
     'thickness': {

--- a/EasyReflectometry/sample/layers.py
+++ b/EasyReflectometry/sample/layers.py
@@ -4,6 +4,7 @@ from typing import List
 
 import yaml
 from easyCore.Objects.Groups import BaseCollection
+
 from EasyReflectometry.sample.layer import Layer
 
 

--- a/EasyReflectometry/sample/material.py
+++ b/EasyReflectometry/sample/material.py
@@ -1,16 +1,22 @@
 __author__ = 'github.com/arm61'
 
-from typing import ClassVar
 from copy import deepcopy
+from typing import ClassVar
 
 import yaml
 from easyCore import np
-from easyCore.Objects.ObjectClasses import Parameter, BaseObj
 from easyCore.Fitting.Constraints import FunctionalConstraint
+from easyCore.Objects.ObjectClasses import (
+    BaseObj,
+    Parameter,
+)
 
-from EasyReflectometry.special.calculations import (weighted_average_sld,
-                                                    neutron_scattering_length,
-                                                    molecular_weight, density_to_sld)
+from EasyReflectometry.special.calculations import (
+    density_to_sld,
+    molecular_weight,
+    neutron_scattering_length,
+    weighted_average_sld,
+)
 
 MATERIAL_DEFAULTS = {
     'sld': {

--- a/EasyReflectometry/sample/materials.py
+++ b/EasyReflectometry/sample/materials.py
@@ -1,10 +1,17 @@
 __author__ = 'github.com/arm61'
 
-from typing import List, Union
+from typing import (
+    List,
+    Union,
+)
 
 import yaml
 from easyCore.Objects.Groups import BaseCollection
-from EasyReflectometry.sample.material import Material, MaterialMixture
+
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialMixture,
+)
 
 
 class Materials(BaseCollection):

--- a/EasyReflectometry/sample/structure.py
+++ b/EasyReflectometry/sample/structure.py
@@ -1,9 +1,13 @@
 __author__ = 'github.com/arm61'
 
-from typing import List, Union
+from typing import (
+    List,
+    Union,
+)
 
 import yaml
 from easyCore.Objects.Groups import BaseCollection
+
 from EasyReflectometry.sample.item import MultiLayer
 from EasyReflectometry.sample.layer import Layer
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 import EasyReflectometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ source = ['EasyReflectometry']
 organization = 'easyScience'
 repo = 'EasyReflectometryLib'
 
-[tool.black]
-line_length = 88
-
 [tool.isort]
 line_length = 88
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "black",
     "build",
     "codecov>=2.1.11",
     "coverage",
     "coveralls",
     "flake8>=6.0.0",
     "ipykernel",
+    "isort",
     "jupyter>=1.0.0",
     "jupyterlab",
     "nbsphinx",
@@ -59,6 +61,9 @@ documentation = "https://docs.easyreflectometry.org"
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.hatch.build.targets.wheel]
+packages = ["EasyReflectometry"]
+
 [tool.coverage.run]
 source = ['EasyReflectometry']
 
@@ -66,8 +71,14 @@ source = ['EasyReflectometry']
 organization = 'easyScience'
 repo = 'EasyReflectometryLib'
 
-[tool.hatch.build.targets.wheel]
-packages = ["EasyReflectometry"]
+[tool.black]
+line_length = 88
+
+[tool.isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 2
 
 [tool.tox]
 legacy_tox_ini = """

--- a/tests/calculators/test_refl1d_calc.py
+++ b/tests/calculators/test_refl1d_calc.py
@@ -6,10 +6,15 @@ Tests for Refl1d class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
-from EasyReflectometry.calculators.refl1d import Refl1d
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
 from refl1d import names
+
+from EasyReflectometry.calculators.refl1d import Refl1d
 
 
 class TestRefl1d(unittest.TestCase):

--- a/tests/calculators/test_refnx_calc.py
+++ b/tests/calculators/test_refnx_calc.py
@@ -6,10 +6,15 @@ Tests for Refnx class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
-from EasyReflectometry.calculators.refnx import Refnx
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
 from refnx import reflect
+
+from EasyReflectometry.calculators.refnx import Refnx
 
 
 class TestRefnx(unittest.TestCase):

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -6,15 +6,23 @@ Tests for Layer class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
 from EasyReflectometry.experiment.model import Model
-from EasyReflectometry.sample.material import Material
+from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.item import (
+    MultiLayer,
+    RepeatingMultiLayer,
+)
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import RepeatingMultiLayer, MultiLayer
+from EasyReflectometry.sample.material import Material
 from EasyReflectometry.sample.structure import Structure
-from EasyReflectometry.interface import InterfaceFactory
 
 
 class TestModel(unittest.TestCase):

--- a/tests/interfaces/test_refl1d_inter.py
+++ b/tests/interfaces/test_refl1d_inter.py
@@ -6,8 +6,13 @@ Tests for Refnx class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
 from EasyReflectometry.interfaces.refl1d import Refl1d
 from EasyReflectometry.sample.material import Material
 

--- a/tests/interfaces/test_refnx_inter.py
+++ b/tests/interfaces/test_refnx_inter.py
@@ -6,8 +6,13 @@ Tests for Refnx class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
 from EasyReflectometry.interfaces.refnx import Refnx
 from EasyReflectometry.sample.material import Material
 

--- a/tests/sample/items/test_multilayer.py
+++ b/tests/sample/items/test_multilayer.py
@@ -6,13 +6,19 @@ Tests for Item class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
-from EasyReflectometry.sample.material import Material
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.item import MultiLayer
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import MultiLayer
-from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.material import Material
 
 
 class TestMultiLayer(unittest.TestCase):

--- a/tests/sample/items/test_repeating_multilayer.py
+++ b/tests/sample/items/test_repeating_multilayer.py
@@ -6,13 +6,20 @@ Tests for Item class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
-from EasyReflectometry.sample.material import Material
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.item import RepeatingMultiLayer
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import RepeatingMultiLayer
-from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.material import Material
+
 
 class TestRepeatingMultiLayer(unittest.TestCase):
 

--- a/tests/sample/items/test_surfactant_layer.py
+++ b/tests/sample/items/test_surfactant_layer.py
@@ -6,13 +6,23 @@ Tests for Item class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
-from EasyReflectometry.sample.material import Material
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.item import (
+    MultiLayer,
+    RepeatingMultiLayer,
+    SurfactantLayer,
+)
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import RepeatingMultiLayer, MultiLayer, SurfactantLayer
-from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.material import Material
 
 
 class TestSurfactantLayer(unittest.TestCase):

--- a/tests/sample/test_layer.py
+++ b/tests/sample/test_layer.py
@@ -6,12 +6,23 @@ Tests for Layer class module
 
 import os
 import unittest
-from EasyReflectometry.special.calculations import apm_to_sld, neutron_scattering_length
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
-from EasyReflectometry.sample.material import Material
-from EasyReflectometry.sample.layer import Layer, LayerApm
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
 from EasyReflectometry.interface import InterfaceFactory
+from EasyReflectometry.sample.layer import (
+    Layer,
+    LayerApm,
+)
+from EasyReflectometry.sample.material import Material
+from EasyReflectometry.special.calculations import (
+    apm_to_sld,
+    neutron_scattering_length,
+)
 
 
 class TestLayer(unittest.TestCase):

--- a/tests/sample/test_layers.py
+++ b/tests/sample/test_layers.py
@@ -6,12 +6,17 @@ Tests for Layers class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
-from EasyReflectometry.sample.material import Material
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
+from EasyReflectometry.sample.item import RepeatingMultiLayer
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import RepeatingMultiLayer
+from EasyReflectometry.sample.material import Material
 
 
 class TestLayers(unittest.TestCase):

--- a/tests/sample/test_material.py
+++ b/tests/sample/test_material.py
@@ -5,9 +5,15 @@ Tests for Material class module
 """
 
 import unittest
+
 import numpy as np
 from numpy.testing import assert_almost_equal
-from EasyReflectometry.sample.material import Material, MaterialDensity, MaterialMixture
+
+from EasyReflectometry.sample.material import (
+    Material,
+    MaterialDensity,
+    MaterialMixture,
+)
 
 
 class TestMaterial(unittest.TestCase):

--- a/tests/sample/test_materials.py
+++ b/tests/sample/test_materials.py
@@ -5,6 +5,7 @@ Tests for Layers class module
 """
 
 import unittest
+
 from EasyReflectometry.sample.material import Material
 from EasyReflectometry.sample.materials import Materials
 

--- a/tests/sample/test_structure.py
+++ b/tests/sample/test_structure.py
@@ -6,12 +6,17 @@ Tests for Model class module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
-from EasyReflectometry.sample.material import Material
+from numpy.testing import (
+    assert_almost_equal,
+    assert_equal,
+)
+
+from EasyReflectometry.sample.item import RepeatingMultiLayer
 from EasyReflectometry.sample.layer import Layer
 from EasyReflectometry.sample.layers import Layers
-from EasyReflectometry.sample.item import RepeatingMultiLayer
+from EasyReflectometry.sample.material import Material
 from EasyReflectometry.sample.structure import Structure
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,12 +6,21 @@ Tests for data module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal
 import scipp as sc
-from orsopy.fileio import load_orso, Header
+from numpy.testing import assert_almost_equal
+from orsopy.fileio import (
+    Header,
+    load_orso,
+)
+
 import EasyReflectometry
-from EasyReflectometry.data import load, _load_orso, _load_txt
+from EasyReflectometry.data import (
+    _load_orso,
+    _load_txt,
+    load,
+)
 
 
 class TestData(unittest.TestCase):

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -5,17 +5,25 @@ Tests for fitting module
 
 import os
 import unittest
+
 import numpy as np
-from numpy.testing import assert_almost_equal
 import scipp as sc
-from orsopy.fileio import load_orso, Header
+from numpy.testing import assert_almost_equal
+from orsopy.fileio import (
+    Header,
+    load_orso,
+)
+
 import EasyReflectometry
-from EasyReflectometry.sample import Layer, Structure
-from EasyReflectometry.sample.material import Material
-from EasyReflectometry.experiment.model import Model
 from EasyReflectometry.data import load
-from EasyReflectometry.interface import InterfaceFactory as Interface
+from EasyReflectometry.experiment.model import Model
 from EasyReflectometry.fitting import Fitter
+from EasyReflectometry.interface import InterfaceFactory as Interface
+from EasyReflectometry.sample import (
+    Layer,
+    Structure,
+)
+from EasyReflectometry.sample.material import Material
 
 
 class TestFitting(unittest.TestCase):

--- a/vscode-template/settings.json
+++ b/vscode-template/settings.json
@@ -1,0 +1,16 @@
+{
+    "black-formatter.args": ["--config", "pyproject.toml"],
+
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        },
+    },
+    "isort.args": ["-m", "3", "--fgw", "2"],
+}


### PR DESCRIPTION
The CI pipeline will now fail if python imports are done "wrongly" according to isort.

The requirements for the `isort` sorting are defined in `pyproject.toml`
- all python files have been sorted accordingly

It is also possible to get the requirements applied on file save in VSCode by using the `settings.json` file in `vscode_template`.

To help the user in case of a failing pipeline the following now step echo's a potential resolution to the error.  This is not an optimal solution, but it is considered good enough for now.

Bumped:
- actions/setup-python@v5 
- actions/checkout@v4