### PR TITLE
Make it clear that sld and isld are managed through constraints

### DIFF
--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -87,6 +87,8 @@ class LayerAreaPerMolecule(Layer):
         :param name: Name of the layer, defaults to "EasyLayerAreaPerMolecule"
         :param interface: Interface object, defaults to `None`
         """
+
+        # Create the solvated molecule and corresponding constraints
         molecule = Material.from_pars(0.0, 0.0, name=molecular_formula, interface=interface)
 
         default_options = deepcopy(LAYER_AREA_PER_MOLECULE_DETAILS)
@@ -95,7 +97,7 @@ class LayerAreaPerMolecule(Layer):
         scattering_length_real = Parameter('scattering_length_real', 0.0, **default_options['sl'])
         scattering_length_imag = Parameter('scattering_length_imag', 0.0, **default_options['isl'])
 
-        # Constrain the sld value for the material (self.molecule.sld)
+        # Constrain the sld value for the molecule
         constraint = FunctionalConstraint(
             dependent_obj=molecule.sld,
             func=area_per_molecule_to_sld,
@@ -105,7 +107,7 @@ class LayerAreaPerMolecule(Layer):
         area_per_molecule.user_constraints['area_per_molecule'] = constraint
         scattering_length_real.user_constraints['area_per_molecule'] = constraint
 
-        # Constrain the isld value for the material (self.molecule.isld)
+        # Constrain the isld value for the molecule
         iconstraint = FunctionalConstraint(
             dependent_obj=molecule.isld,
             func=area_per_molecule_to_sld,
@@ -131,6 +133,7 @@ class LayerAreaPerMolecule(Layer):
         self._add_component('_scattering_length_real', scattering_length_real)
         self._add_component('_scattering_length_imag', scattering_length_imag)
         self._add_component('_area_per_molecule', area_per_molecule)
+
         scattering_length = neutron_scattering_length(molecular_formula)
         self._scattering_length_real.value = scattering_length.real
         self._scattering_length_imag.value = scattering_length.imag

--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -87,19 +87,17 @@ class LayerAreaPerMolecule(Layer):
         :param name: Name of the layer, defaults to "EasyLayerAreaPerMolecule"
         :param interface: Interface object, defaults to `None`
         """
-        scattering_length = neutron_scattering_length(molecular_formula)
+        molecule = Material.from_pars(0.0, 0.0, name=molecular_formula, interface=interface)
+
         default_options = deepcopy(LAYER_AREA_PER_MOLECULE_DETAILS)
         del default_options['sl']['value']
         del default_options['isl']['value']
-        scattering_length_real = Parameter('scattering_length_real', scattering_length.real, **default_options['sl'])
-        scattering_length_imag = Parameter('scattering_length_imag', scattering_length.imag, **default_options['isl'])
-        sld_real = area_per_molecule_to_sld(scattering_length_real.raw_value, thickness.raw_value, area_per_molecule.raw_value)
-        sld_imag = area_per_molecule_to_sld(scattering_length_imag.raw_value, thickness.raw_value, area_per_molecule.raw_value)
+        scattering_length_real = Parameter('scattering_length_real', 0.0, **default_options['sl'])
+        scattering_length_imag = Parameter('scattering_length_imag', 0.0, **default_options['isl'])
 
-        material = Material.from_pars(sld_real, sld_imag, name=molecular_formula, interface=interface)
-
+        # Constrain the sld value for the material (self.molecule.sld)
         constraint = FunctionalConstraint(
-            dependent_obj=material.sld,
+            dependent_obj=molecule.sld,
             func=area_per_molecule_to_sld,
             independent_objs=[scattering_length_real, thickness, area_per_molecule],
         )
@@ -107,8 +105,9 @@ class LayerAreaPerMolecule(Layer):
         area_per_molecule.user_constraints['area_per_molecule'] = constraint
         scattering_length_real.user_constraints['area_per_molecule'] = constraint
 
+        # Constrain the isld value for the material (self.molecule.isld)
         iconstraint = FunctionalConstraint(
-            dependent_obj=material.isld,
+            dependent_obj=molecule.isld,
             func=area_per_molecule_to_sld,
             independent_objs=[scattering_length_imag, thickness, area_per_molecule],
         )
@@ -116,14 +115,14 @@ class LayerAreaPerMolecule(Layer):
         area_per_molecule.user_constraints['iarea_per_molecule'] = iconstraint
         scattering_length_imag.user_constraints['iarea_per_molecule'] = iconstraint
 
-        solvated_material = MaterialSolvated(
-            material=material,
+        solvated_molecule = MaterialSolvated(
+            material=molecule,
             solvent=solvent,
             solvent_fraction=solvent_fraction,
             interface=interface,
         )
         super().__init__(
-            material=solvated_material,
+            material=solvated_molecule,
             thickness=thickness,
             roughness=roughness,
             name=name,
@@ -132,6 +131,9 @@ class LayerAreaPerMolecule(Layer):
         self._add_component('_scattering_length_real', scattering_length_real)
         self._add_component('_scattering_length_imag', scattering_length_imag)
         self._add_component('_area_per_molecule', area_per_molecule)
+        scattering_length = neutron_scattering_length(molecular_formula)
+        self._scattering_length_real.value = scattering_length.real
+        self._scattering_length_imag.value = scattering_length.imag
         self._molecular_formula = molecular_formula
         self.interface = interface
 
@@ -207,6 +209,11 @@ class LayerAreaPerMolecule(Layer):
         return self._area_per_molecule
 
     @property
+    def molecule(self) -> Material:
+        """Get the molecule material."""
+        return self.material.material
+
+    @property
     def solvent(self) -> Material:
         """Get the solvent material."""
         return self.material.solvent
@@ -248,9 +255,11 @@ class LayerAreaPerMolecule(Layer):
         """
         self._molecular_formula = formula_string
         scattering_length = neutron_scattering_length(formula_string)
+        # The molecule is also being updated through the constraints
         self._scattering_length_real.value = scattering_length.real
         self._scattering_length_imag.value = scattering_length.imag
-        self.material.material.name = formula_string
+
+        self.molecule.name = formula_string
         self.material._update_name()
 
     @property

--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -6,7 +6,7 @@ from easyCore import np
 from easyCore.Fitting.Constraints import FunctionalConstraint
 from easyCore.Objects.ObjectClasses import Parameter
 
-from EasyReflectometry.special.calculations import area_per_molecule_to_sld
+from EasyReflectometry.special.calculations import area_per_molecule_to_scattering_length_density
 from EasyReflectometry.special.calculations import neutron_scattering_length
 
 from ..materials.material import Material
@@ -97,25 +97,25 @@ class LayerAreaPerMolecule(Layer):
         scattering_length_real = Parameter('scattering_length_real', 0.0, **default_options['sl'])
         scattering_length_imag = Parameter('scattering_length_imag', 0.0, **default_options['isl'])
 
-        # Constrain the sld value for the molecule
-        constraint = FunctionalConstraint(
+        # Constrain the real part of the sld value for the molecule
+        constraint_sld_real = FunctionalConstraint(
             dependent_obj=molecule.sld,
-            func=area_per_molecule_to_sld,
+            func=area_per_molecule_to_scattering_length_density,
             independent_objs=[scattering_length_real, thickness, area_per_molecule],
         )
-        thickness.user_constraints['area_per_molecule'] = constraint
-        area_per_molecule.user_constraints['area_per_molecule'] = constraint
-        scattering_length_real.user_constraints['area_per_molecule'] = constraint
+        thickness.user_constraints['area_per_molecule'] = constraint_sld_real
+        area_per_molecule.user_constraints['area_per_molecule'] = constraint_sld_real
+        scattering_length_real.user_constraints['area_per_molecule'] = constraint_sld_real
 
-        # Constrain the isld value for the molecule
-        iconstraint = FunctionalConstraint(
+        # Constrain the imaginary part of the sld value for the molecule
+        constraint_sld_imag = FunctionalConstraint(
             dependent_obj=molecule.isld,
-            func=area_per_molecule_to_sld,
+            func=area_per_molecule_to_scattering_length_density,
             independent_objs=[scattering_length_imag, thickness, area_per_molecule],
         )
-        thickness.user_constraints['iarea_per_molecule'] = iconstraint
-        area_per_molecule.user_constraints['iarea_per_molecule'] = iconstraint
-        scattering_length_imag.user_constraints['iarea_per_molecule'] = iconstraint
+        thickness.user_constraints['iarea_per_molecule'] = constraint_sld_imag
+        area_per_molecule.user_constraints['iarea_per_molecule'] = constraint_sld_imag
+        scattering_length_imag.user_constraints['iarea_per_molecule'] = constraint_sld_imag
 
         solvated_molecule = MaterialSolvated(
             material=molecule,

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import Optional
 
 from easyCore.Fitting.Constraints import FunctionalConstraint
 from easyCore.Objects.ObjectClasses import Parameter
@@ -34,7 +35,7 @@ class MaterialMixture(BaseElement):
         material_a: Material,
         material_b: Material,
         fraction: Parameter,
-        name: str = None,
+        name: Optional[str] = None,
         interface=None,
     ):
         """Constructor.
@@ -83,9 +84,9 @@ class MaterialMixture(BaseElement):
         material_b = Material.default()
         fraction = Parameter('fraction', **MATERIALMIXTURE_DEFAULTS['fraction'])
         return cls(
-            material_a,
-            material_b,
-            fraction,
+            material_a=material_a,
+            material_b=material_b,
+            fraction=fraction,
             interface=interface,
         )
 
@@ -95,7 +96,7 @@ class MaterialMixture(BaseElement):
         material_a: Material,
         material_b: Material,
         fraction: float,
-        name=None,
+        name: Optional[str] = None,
         interface=None,
     ) -> MaterialMixture:
         """Instance of mixture of two materials where the parameters are known.
@@ -111,9 +112,9 @@ class MaterialMixture(BaseElement):
         fraction = Parameter('fraction', fraction, **default_options['fraction'])
 
         return cls(
-            material_a,
-            material_b,
-            fraction,
+            material_a=material_a,
+            material_b=material_b,
+            fraction=fraction,
             name=name,
             interface=interface,
         )

--- a/EasyReflectometry/special/calculations.py
+++ b/EasyReflectometry/special/calculations.py
@@ -50,7 +50,11 @@ def molecular_weight(formula: str) -> float:
     return mw
 
 
-def area_per_molecule_to_sld(scattering_length: float, thickness: float, area_per_molecule: float) -> float:
+def area_per_molecule_to_scattering_length_density(
+    scattering_length: float,
+    thickness: float,
+    area_per_molecule: float,
+) -> float:
     """
     Find the scattering length density for a given area per molecule.
 

--- a/tests/special/test_calculations.py
+++ b/tests/special/test_calculations.py
@@ -4,7 +4,7 @@ import unittest
 
 from numpy.testing import assert_almost_equal
 
-from EasyReflectometry.special.calculations import area_per_molecule_to_sld
+from EasyReflectometry.special.calculations import area_per_molecule_to_scattering_length_density
 from EasyReflectometry.special.calculations import molecular_weight
 from EasyReflectometry.special.calculations import neutron_scattering_length
 from EasyReflectometry.special.calculations import weighted_average
@@ -30,5 +30,5 @@ class TestMaterialMixture(unittest.TestCase):
         assert_almost_equal(a, 18.01528)
 
     def test_area_per_molecule_to_sld(self) -> None:
-        a = area_per_molecule_to_sld(2, 1, 0.5)
+        a = area_per_molecule_to_scattering_length_density(2, 1, 0.5)
         assert_almost_equal(a, 4e6)


### PR DESCRIPTION
No changes to logic.  Code was working as intended.

However, constructor has been changed to underline that the `sld` and `isld` values are handled though constraints.  Notice that the variables now are initialized using 0 as their numeric value.  The value is then set in the end of the constructor and it is propagated to the molecule.sld and molecule.isld through the constraint. 

