### PR TITLE
Adjustments to fit the App

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+# Configuration for the realease-drafter workflow.
+# https://github.com/marketplace/actions/release-drafter
+
+name-template: v$NEXT_PATCH_VERSION 🌈
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+- title: 🚀 Features
+  labels:
+  - feature
+  - enhancement
+- title: 🐛 Bug Fixes
+  labels:
+  - fix
+  - bugfix
+  - bug
+- title: 🧰 Maintenance
+  labels:
+  - chore
+  - documentation
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+    - major
+  minor:
+    labels:
+    - minor
+  patch:
+    labels:
+    - patch
+  default: patch
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,6 +1,6 @@
-# This pipeline
-# - builds developer documentation 
-# - pushes documentation to gh-pages branch of the same repository
+# This workflow will
+# - build developer documentation 
+# - push documentation to gh-pages branch of the same repository
 #
 # Deployment is handled by pages-build-deployment bot
 
@@ -26,24 +26,23 @@ jobs:
       uses: actions/checkout@master
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-    - name: Upgrade pip
-      run: |
-        python -m pip install --upgrade pip
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
-    - name: Install Pandoc, EasyReflectometry and dependencies
+    - name: Install Pandoc, repo and dependencies
       run: |
         sudo apt install pandoc
-        pip install . '.[dev,docs]'
+        pip install . '.[docs]'
+
     - name: Build and Commit
       uses: sphinx-notes/pages@master
       with:
         install_requirements: true
-        documentation_path: docs
+        documentation_path: docs/src
     - name: Push changes
       uses: ad-m/github-push-action@master
       continue-on-error: true
       with:
+        github_token: ${{ secrets.CORE_TOKEN }}
         branch: gh-pages

--- a/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,0 +1,23 @@
+# This workflow will
+# - verify that a PR has a known label before it can be merged.
+#
+# A label is needed for the release-drafter workflow to generate the notes.
+
+name: Verify PR labels
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: Verify that the PR has a valid label
+    steps:
+    - name: Verify PR label action
+      uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      id: verify-pr-label
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        valid-labels: chore, fix, bugfix, bug, enhancement, feature, dependencies, documentation
+        pull-request-number: ${{ github.event.pull_request.number }}
+        disable-reviews: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+# This workflow will
+# - draft a new release the next time a release is tagged.
+#
+# Uses the release-drafter.yml configuration file in the .github directory.
+# https://github.com/marketplace/actions/release-drafter
+
+
+name: Release Drafter
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -9,10 +9,9 @@ from easyCore import np
 from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.ObjectClasses import Parameter
 
+from EasyReflectometry.sample import BaseAssembly
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
-from EasyReflectometry.sample import Multilayer
-from EasyReflectometry.sample import RepeatingMultilayer
 from EasyReflectometry.sample import Sample
 
 LAYER_DETAILS = {
@@ -47,6 +46,13 @@ class Model(BaseObj):
     """Model is the class that represents the experiment.
     It is used to store the information about the experiment and to perform the calculations.
     """
+
+    # Added in super().__init__
+    name: str
+    sample: Sample
+    scale: Parameter
+    background: Parameter
+    resolution: Parameter
 
     def __init__(
         self,
@@ -126,16 +132,18 @@ class Model(BaseObj):
             interface=interface,
         )
 
-    def add_item(self, *items: Layer | RepeatingMultilayer) -> None:
+    def add_item(self, *assemblies: list[BaseAssembly]) -> None:
         """Add a layer or item to the model sample.
 
-        :param items: Layers or items to add to model sample.
+        :param assemblies: Assemblies to add to model sample.
         """
-        for arg in items:
-            if issubclass(arg.__class__, Multilayer):
+        for arg in assemblies:
+            if issubclass(arg.__class__, BaseAssembly):
                 self.sample.append(arg)
                 if self.interface is not None:
                     self.interface().add_item_to_model(arg.uid, self.uid)
+            else:
+                raise ValueError(f'Object {arg} is not a valid type, must be a child of BaseAssembly.')
 
     def duplicate_item(self, idx: int) -> None:
         """Duplicate a given item or layer in a sample.

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -197,3 +197,15 @@ class Model(BaseObj):
     def __repr__(self) -> str:
         """String representation of the layer."""
         return yaml.dump(self._dict_repr, sort_keys=False)
+
+    def as_dict(self, skip: list = None) -> dict:
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
+        if skip is None:
+            skip = []
+        this_dict = super().as_dict(skip=skip)
+        this_dict['sample'] = self.sample.as_dict()
+        return this_dict

--- a/EasyReflectometry/sample/__init__.py
+++ b/EasyReflectometry/sample/__init__.py
@@ -3,11 +3,11 @@ from .assemblies.gradient_layer import GradientLayer
 from .assemblies.multilayer import Multilayer
 from .assemblies.repeating_multilayer import RepeatingMultilayer
 from .assemblies.surfactant_layer import SurfactantLayer
-from .elements.layer_collection import LayerCollection
 from .elements.layers.layer import Layer
 from .elements.layers.layer_area_per_molecule import LayerAreaPerMolecule
-from .elements.material_collection import MaterialCollection
+from .elements.layers.layer_collection import LayerCollection
 from .elements.materials.material import Material
+from .elements.materials.material_collection import MaterialCollection
 from .elements.materials.material_mixture import MaterialMixture
 from .elements.materials.material_solvated import MaterialSolvated
 from .sample import Sample

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -182,8 +182,7 @@ class BaseAssembly(BaseObj):
             raise Exception('Roughness constraints not setup')
 
     def as_dict(self, skip: list = None) -> dict:
-        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
-        The resulting dict matches the paramters in __init__
+        """Should produce a cleaned dict that matches the paramters in __init__
 
         :param skip: List of keys to skip, defaults to `None`.
         """

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -82,7 +82,7 @@ class BaseAssembly(BaseObj):
             self.layers[0] = layer
 
     @property
-    def back_layer(self) -> Optional[None]:
+    def back_layer(self) -> Optional[Layer]:
         """Get the back layer in the assembly."""
 
         if len(self.layers) < 2:

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -1,16 +1,14 @@
-from abc import abstractmethod
 from typing import Any
 from typing import Optional
 
-import yaml
 from easyCore.Fitting.Constraints import ObjConstraint
-from easyCore.Objects.ObjectClasses import BaseObj
 
+from ..base_core import BaseCore
 from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer import Layer
 
 
-class BaseAssembly(BaseObj):
+class BaseAssembly(BaseCore):
     """Assembly of layers.
     The front layer (front_layer) is the layer the neutron beam starts in, it has an index of 0.
     The back layer (back_layer) is the final layer from which the unreflected neutron beam is transmitted,
@@ -32,20 +30,12 @@ class BaseAssembly(BaseObj):
         interface,
         **layers: LayerCollection,
     ):
-        super().__init__(name=name, **layers)
+        super().__init__(name=name, interface=interface, **layers)
 
-        # Updates interface using property in base object
-        self.interface = interface
         # Type is needed when fitting in EasyCore
         self._type = type
         self._roughness_constraints_setup = False
         self._thickness_constraints_setup = False
-
-    @abstractmethod
-    def default(cls, interface=None) -> Any: ...
-
-    @abstractmethod
-    def _dict_repr(self) -> dict[str, str]: ...
 
     @property
     def type(self) -> str:
@@ -53,15 +43,6 @@ class BaseAssembly(BaseObj):
         Needed by the GUI.
         """
         return self._type
-
-    @property
-    def uid(self) -> int:
-        """Get UID from the borg map"""
-        return self._borg.map.convert_id_to_key(self)
-
-    def __repr__(self) -> str:
-        """String representation of the object."""
-        return yaml.dump(self._dict_repr, sort_keys=False)
 
     @property
     def front_layer(self) -> Optional[Layer]:
@@ -180,13 +161,3 @@ class BaseAssembly(BaseObj):
                 self.front_layer.roughness.user_constraints[f'roughness_{i}'].enabled = False
         else:
             raise Exception('Roughness constraints not setup')
-
-    def as_dict(self, skip: list = None) -> dict:
-        """Should produce a cleaned dict that matches the paramters in __init__
-
-        :param skip: List of keys to skip, defaults to `None`.
-        """
-        if skip is None:
-            skip = []
-        this_dict = super().as_dict(skip=skip)
-        return this_dict

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -42,12 +42,10 @@ class BaseAssembly(BaseObj):
         self._thickness_constraints_setup = False
 
     @abstractmethod
-    def default(cls, interface=None) -> Any:
-        ...
+    def default(cls, interface=None) -> Any: ...
 
     @abstractmethod
-    def _dict_repr(self) -> dict[str, str]:
-        ...
+    def _dict_repr(self) -> dict[str, str]: ...
 
     @property
     def type(self) -> str:
@@ -182,3 +180,14 @@ class BaseAssembly(BaseObj):
                 self.front_layer.roughness.user_constraints[f'roughness_{i}'].enabled = False
         else:
             raise Exception('Roughness constraints not setup')
+
+    def as_dict(self, skip: list = None) -> dict:
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
+        if skip is None:
+            skip = []
+        this_dict = super().as_dict(skip=skip)
+        return this_dict

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -50,6 +50,13 @@ class BaseAssembly(BaseObj):
         ...
 
     @property
+    def type(self) -> str:
+        """Get type of the assembly.
+        Needed by the GUI.
+        """
+        return self._type
+
+    @property
     def uid(self) -> int:
         """Get UID from the borg map"""
         return self._borg.map.convert_id_to_key(self)

--- a/EasyReflectometry/sample/assemblies/base_assembly.py
+++ b/EasyReflectometry/sample/assemblies/base_assembly.py
@@ -4,8 +4,8 @@ from typing import Optional
 from easyCore.Fitting.Constraints import ObjConstraint
 
 from ..base_core import BaseCore
-from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer import Layer
+from ..elements.layers.layer_collection import LayerCollection
 
 
 class BaseAssembly(BaseCore):

--- a/EasyReflectometry/sample/assemblies/gradient_layer.py
+++ b/EasyReflectometry/sample/assemblies/gradient_layer.py
@@ -159,6 +159,7 @@ class GradientLayer(BaseAssembly):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
+        # Determined in __init__
         del this_dict['layers']
         return this_dict
 

--- a/EasyReflectometry/sample/assemblies/gradient_layer.py
+++ b/EasyReflectometry/sample/assemblies/gradient_layer.py
@@ -158,8 +158,6 @@ class GradientLayer(BaseAssembly):
 
         :param skip: List of keys to skip, defaults to `None`.
         """
-        if skip is None:
-            skip = []
         this_dict = super().as_dict(skip=skip)
         del this_dict['layers']
         return this_dict

--- a/EasyReflectometry/sample/assemblies/gradient_layer.py
+++ b/EasyReflectometry/sample/assemblies/gradient_layer.py
@@ -153,8 +153,10 @@ class GradientLayer(BaseAssembly):
         }
 
     def as_dict(self, skip: list = None) -> dict:
-        """
-        Cleaned dictionary. Custom as_dict method to skip generated layers.
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
         """
         if skip is None:
             skip = []

--- a/EasyReflectometry/sample/assemblies/gradient_layer.py
+++ b/EasyReflectometry/sample/assemblies/gradient_layer.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from numpy import arange
 
-from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer import Layer
+from ..elements.layers.layer_collection import LayerCollection
 from ..elements.materials.material import Material
 from .base_assembly import BaseAssembly
 

--- a/EasyReflectometry/sample/assemblies/multilayer.py
+++ b/EasyReflectometry/sample/assemblies/multilayer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer import Layer
+from ..elements.layers.layer_collection import LayerCollection
 from .base_assembly import BaseAssembly
 
 

--- a/EasyReflectometry/sample/assemblies/repeating_multilayer.py
+++ b/EasyReflectometry/sample/assemblies/repeating_multilayer.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 
 from easyCore.Objects.ObjectClasses import Parameter
 
-from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer import Layer
+from ..elements.layers.layer_collection import LayerCollection
 from .multilayer import Multilayer
 
 REPEATINGMULTILAYER_DETAILS = {

--- a/EasyReflectometry/sample/assemblies/surfactant_layer.py
+++ b/EasyReflectometry/sample/assemblies/surfactant_layer.py
@@ -224,42 +224,52 @@ class SurfactantLayer(BaseAssembly):
         """
         if head_layer_thickness:
             head_layer_thickness_constraint = ObjConstraint(
-                self.head_layer.thickness, '', another_contrast.head_layer.thickness
+                dependent_obj=self.head_layer.thickness,
+                operator='',
+                independent_obj=another_contrast.head_layer.thickness,
             )
             another_contrast.head_layer.thickness.user_constraints[f'{another_contrast.name}'] = (
                 head_layer_thickness_constraint
             )
         if tail_layer_thickness:
             tail_layer_thickness_constraint = ObjConstraint(
-                self.tail_layer.thickness, '', another_contrast.tail_layer.thickness
+                dependent_obj=self.tail_layer.thickness, operator='', independent_obj=another_contrast.tail_layer.thickness
             )
             another_contrast.tail_layer.thickness.user_constraints[f'{another_contrast.name}'] = (
                 tail_layer_thickness_constraint
             )
         if head_layer_area_per_molecule:
             head_layer_area_per_molecule_constraint = ObjConstraint(
-                self.head_layer._area_per_molecule, '', another_contrast.head_layer._area_per_molecule
+                dependent_obj=self.head_layer._area_per_molecule,
+                operator='',
+                independent_obj=another_contrast.head_layer._area_per_molecule,
             )
             another_contrast.head_layer._area_per_molecule.user_constraints[f'{another_contrast.name}'] = (
                 head_layer_area_per_molecule_constraint
             )
         if tail_layer_area_per_molecule:
             tail_layer_area_per_molecule_constraint = ObjConstraint(
-                self.tail_layer._area_per_molecule, '', another_contrast.tail_layer._area_per_molecule
+                dependent_obj=self.tail_layer._area_per_molecule,
+                operator='',
+                independent_obj=another_contrast.tail_layer._area_per_molecule,
             )
             another_contrast.tail_layer._area_per_molecule.user_constraints[f'{another_contrast.name}'] = (
                 tail_layer_area_per_molecule_constraint
             )
         if head_layer_fraction:
             head_layer_fraction_constraint = ObjConstraint(
-                self.head_layer.material._fraction, '', another_contrast.head_layer.material._fraction
+                dependent_obj=self.head_layer.material._fraction,
+                operator='',
+                independent_obj=another_contrast.head_layer.material._fraction,
             )
             another_contrast.head_layer.material._fraction.user_constraints[f'{another_contrast.name}'] = (
                 head_layer_fraction_constraint
             )
         if tail_layer_fraction:
             tail_layer_fraction_constraint = ObjConstraint(
-                self.tail_layer.material._fraction, '', another_contrast.tail_layer.material._fraction
+                dependent_obj=self.tail_layer.material._fraction,
+                operator='',
+                independent_obj=another_contrast.tail_layer.material._fraction,
             )
             another_contrast.tail_layer.material._fraction.user_constraints[f'{another_contrast.name}'] = (
                 tail_layer_fraction_constraint

--- a/EasyReflectometry/sample/assemblies/surfactant_layer.py
+++ b/EasyReflectometry/sample/assemblies/surfactant_layer.py
@@ -91,7 +91,7 @@ class SurfactantLayer(BaseAssembly):
             roughness=3.0,
             name='DPPC Head',
         )
-        return cls([tail, head], name='DPPC', interface=interface)
+        return cls([tail, head], interface=interface)
 
     @classmethod
     def from_pars(
@@ -269,10 +269,12 @@ class SurfactantLayer(BaseAssembly):
     def _dict_repr(self) -> dict:
         """A simplified dict representation."""
         return {
-            'head_layer': self.head_layer._dict_repr,
-            'tail_layer': self.tail_layer._dict_repr,
-            'area per molecule constrained': self.constrain_area_per_molecule,
-            'conformal roughness': self.conformal_roughness,
+            self.name: {
+                'head_layer': self.head_layer._dict_repr,
+                'tail_layer': self.tail_layer._dict_repr,
+                'area per molecule constrained': self.constrain_area_per_molecule,
+                'conformal roughness': self.conformal_roughness,
+            }
         }
 
     def as_dict(self, skip: list = None) -> dict:

--- a/EasyReflectometry/sample/assemblies/surfactant_layer.py
+++ b/EasyReflectometry/sample/assemblies/surfactant_layer.py
@@ -293,8 +293,6 @@ class SurfactantLayer(BaseAssembly):
 
         :param skip: List of keys to skip, defaults to `None`.
         """
-        if skip is None:
-            skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['layers']['data'][0] = self.tail_layer
         this_dict['layers']['data'][1] = self.head_layer

--- a/EasyReflectometry/sample/assemblies/surfactant_layer.py
+++ b/EasyReflectometry/sample/assemblies/surfactant_layer.py
@@ -5,8 +5,8 @@ from typing import Optional
 from easyCore.Fitting.Constraints import ObjConstraint
 from easyCore.Objects.ObjectClasses import Parameter
 
-from ..elements.layer_collection import LayerCollection
 from ..elements.layers.layer_area_per_molecule import LayerAreaPerMolecule
+from ..elements.layers.layer_collection import LayerCollection
 from ..elements.materials.material import Material
 from .base_assembly import BaseAssembly
 

--- a/EasyReflectometry/sample/assemblies/surfactant_layer.py
+++ b/EasyReflectometry/sample/assemblies/surfactant_layer.py
@@ -294,8 +294,8 @@ class SurfactantLayer(BaseAssembly):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
-        this_dict['layers']['data'][0] = self.tail_layer
-        this_dict['layers']['data'][1] = self.head_layer
+        this_dict['layers']['data'][0] = self.tail_layer.as_dict()
+        this_dict['layers']['data'][1] = self.head_layer.as_dict()
         this_dict['constrain_area_per_molecule'] = self.constrain_area_per_molecule
         this_dict['conformal_roughness'] = self.conformal_roughness
         return this_dict

--- a/EasyReflectometry/sample/base_core.py
+++ b/EasyReflectometry/sample/base_core.py
@@ -5,7 +5,7 @@ import yaml
 from easyCore.Objects.ObjectClasses import BaseObj
 
 
-class BaseElement(BaseObj):
+class BaseCore(BaseObj):
     def __init__(
         self,
         name: str,
@@ -13,6 +13,8 @@ class BaseElement(BaseObj):
         **kwargs,
     ):
         super().__init__(name=name, **kwargs)
+
+        # Updates interface using property in base object
         self.interface = interface
 
     @abstractmethod
@@ -37,12 +39,16 @@ class BaseElement(BaseObj):
         """
         return yaml.dump(self._dict_repr, sort_keys=False)
 
-    def as_dict(self, skip: list = None) -> dict:
-        """Should produce a cleaned dict that matches the paramters in __init__
-
-        :param skip: List of keys to skip, defaults to `None`.
-        """
-        if skip is None:
-            skip = []
-        this_dict = super().as_dict(skip=skip)
-        return this_dict
+    # For classes with special serialization needs one must adopt the dict produced by super
+    # def as_dict(self, skip: list = None) -> dict:
+    #    """Should produce a cleaned dict that matches the paramters in __init__
+    #
+    #    :param skip: List of keys to skip, defaults to `None`.
+    #    """
+    #    if skip is None:
+    #        skip = []
+    #    this_dict = super().as_dict(skip=skip)
+    #    ...
+    #    Correct the dict here
+    #    ...
+    #    return this_dict

--- a/EasyReflectometry/sample/elements/base_element.py
+++ b/EasyReflectometry/sample/elements/base_element.py
@@ -16,12 +16,10 @@ class BaseElement(BaseObj):
         self.interface = interface
 
     @abstractmethod
-    def default(cls, interface=None) -> Any:
-        ...
+    def default(cls, interface=None) -> Any: ...
 
     @abstractmethod
-    def _dict_repr(self) -> dict[str, str]:
-        ...
+    def _dict_repr(self) -> dict[str, str]: ...
 
     @property
     def uid(self) -> int:
@@ -38,3 +36,13 @@ class BaseElement(BaseObj):
         :rtype: str
         """
         return yaml.dump(self._dict_repr, sort_keys=False)
+
+    def as_dict(self, skip: list = None) -> dict:
+        """Should produce a cleaned dict that matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
+        if skip is None:
+            skip = []
+        this_dict = super().as_dict(skip=skip)
+        return this_dict

--- a/EasyReflectometry/sample/elements/layers/layer.py
+++ b/EasyReflectometry/sample/elements/layers/layer.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from easyCore import np
 from easyCore.Objects.ObjectClasses import Parameter
 
-from ..base_element import BaseElement
+from ...base_core import BaseCore
 from ..materials.material import Material
 
 LAYER_DETAILS = {
@@ -32,7 +32,7 @@ LAYER_DETAILS = {
 }
 
 
-class Layer(BaseElement):
+class Layer(BaseCore):
     # Added in super().__init__
     #: Material that makes up the layer.
     material: Material

--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -95,6 +95,8 @@ class LayerAreaPerMolecule(Layer):
         del default_options['sl']['value']
         del default_options['isl']['value']
         del default_options['area_per_molecule']['value']
+
+        # Will be added as components later in the init
         _scattering_length_real = Parameter('scattering_length_real', 0.0, **default_options['sl'])
         _scattering_length_imag = Parameter('scattering_length_imag', 0.0, **default_options['isl'])
         _area_per_molecule = Parameter('area_per_molecule', area_per_molecule, **default_options['area_per_molecule'])
@@ -289,8 +291,6 @@ class LayerAreaPerMolecule(Layer):
 
         :param skip: List of keys to skip, defaults to `None`.
         """
-        if skip is None:
-            skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['solvent_fraction'] = self.material._fraction
         del this_dict['material']

--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -292,7 +292,7 @@ class LayerAreaPerMolecule(Layer):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
-        this_dict['solvent_fraction'] = self.material._fraction
+        this_dict['solvent_fraction'] = self.material._fraction.as_dict()
         del this_dict['material']
         del this_dict['_scattering_length_real']
         del this_dict['_scattering_length_imag']

--- a/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/EasyReflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -265,6 +265,12 @@ class LayerAreaPerMolecule(Layer):
         self.molecule.name = formula_string
         self.material._update_name()
 
+    # def _convert_to_dict(self, org_dict, _, **dont_care) -> dict:
+    #     del org_dict['_scattering_length_real']
+    #     del org_dict['_scattering_length_imag']
+    #     del org_dict['_area_per_molecule']
+    #     del org_dict['material']
+
     @property
     def _dict_repr(self) -> dict[str, str]:
         """Dictionary representation of the :py:class:`Layerarea_per_molecule` object. Produces a simple dictionary"""

--- a/EasyReflectometry/sample/elements/layers/layer_collection.py
+++ b/EasyReflectometry/sample/elements/layers/layer_collection.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 __author__ = 'github.com/arm61'
 
-from .base_element_collection import BaseElementCollection
-from .layers.layer import Layer
+from ..base_element_collection import BaseElementCollection
+from .layer import Layer
 
 
 class LayerCollection(BaseElementCollection):

--- a/EasyReflectometry/sample/elements/materials/material.py
+++ b/EasyReflectometry/sample/elements/materials/material.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 from easyCore import np
 from easyCore.Objects.ObjectClasses import Parameter
 
-from ..base_element import BaseElement
+from ...base_core import BaseCore
 
 MATERIAL_DEFAULTS = {
     'sld': {
@@ -32,7 +32,7 @@ MATERIAL_DEFAULTS = {
 }
 
 
-class Material(BaseElement):
+class Material(BaseCore):
     # Added in super().__init__
     sld: ClassVar[Parameter]
     isld: ClassVar[Parameter]

--- a/EasyReflectometry/sample/elements/materials/material_collection.py
+++ b/EasyReflectometry/sample/elements/materials/material_collection.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 __author__ = 'github.com/arm61'
 
-from .base_element_collection import BaseElementCollection
-from .materials.material import Material
-from .materials.material_mixture import MaterialMixture
+from ..base_element_collection import BaseElementCollection
+from .material import Material
+from .material_mixture import MaterialMixture
 
 
 class MaterialCollection(BaseElementCollection):

--- a/EasyReflectometry/sample/elements/materials/material_density.py
+++ b/EasyReflectometry/sample/elements/materials/material_density.py
@@ -180,6 +180,11 @@ class MaterialDensity(Material):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
-        del this_dict['sld'], this_dict['isld'], this_dict['scattering_length_real']
-        del this_dict['scattering_length_imag'], this_dict['molecular_weight']
+        # From Material
+        del this_dict['sld']
+        del this_dict['isld']
+        # Determined in __init__
+        del this_dict['scattering_length_real']
+        del this_dict['scattering_length_imag']
+        del this_dict['molecular_weight']
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_density.py
+++ b/EasyReflectometry/sample/elements/materials/material_density.py
@@ -174,7 +174,11 @@ class MaterialDensity(Material):
         return mat_dict
 
     def as_dict(self, skip: list = []) -> dict[str, str]:
-        """Custom as_dict method to skip necessary things."""
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
         this_dict = super().as_dict(skip=skip)
         del this_dict['sld'], this_dict['isld'], this_dict['scattering_length_real']
         del this_dict['scattering_length_imag'], this_dict['molecular_weight']

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -224,8 +224,6 @@ class MaterialMixture(BaseElement):
 
         :param skip: List of keys to skip, defaults to `None`.
         """
-        if skip is None:
-            skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['material_a'] = self._material_a
         this_dict['material_b'] = self._material_b

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -44,7 +44,7 @@ class MaterialMixture(BaseElement):
         :param material_b: The second material.
         :param fraction: The fraction of material_b in material_a.
         :param name: Name of the material, defaults to None that causes the name to be constructed.
-        :param interface: Calculator interface, defaults to :py:attr:`None`.
+        :param interface: Calculator interface, defaults to `None`.
         """
         super().__init__(
             name,
@@ -105,7 +105,7 @@ class MaterialMixture(BaseElement):
         :param material_b: The second material.
         :param fraction: The fraction of material_b in material_a.
         :param name: Name of the material, defaults to 'EasyMaterialMixture'.
-        :param interface: Calculator interface, defaults to :py:attr:`None`.
+        :param interface: Calculator interface, defaults to `None`.
         """
         default_options = deepcopy(MATERIALMIXTURE_DEFAULTS)
         del default_options['fraction']['value']
@@ -123,12 +123,12 @@ class MaterialMixture(BaseElement):
         return [self._sld, self._isld]
 
     @property
-    def sld(self):
-        return self._sld
+    def sld(self) -> float:
+        return self._sld.raw_value
 
     @property
-    def isld(self):
-        return self._isld
+    def isld(self) -> float:
+        return self._isld.raw_value
 
     def _materials_constraints(self):
         self._sld.enabled = True
@@ -153,40 +153,19 @@ class MaterialMixture(BaseElement):
         iconstraint()
 
     @property
-    def fraction(self) -> Parameter:
-        """
-        :return: the fraction of material a.
-        """
-        return self._fraction
+    def fraction(self) -> float:
+        """Get the fraction of material_b."""
+        return self._fraction.raw_value
 
     @fraction.setter
     def fraction(self, fraction: float) -> None:
-        """
-        Setter for fraction of material a.
+        """Setter for fraction of material_b.
 
-        :param fraction: double
+        :param fraction: The fraction of material_b in material_a.
         """
         if not isinstance(fraction, float):
             raise ValueError('fraction must be a float')
-        self._fraction = fraction
-
-    @property
-    def fraction(self) -> Parameter:
-        """
-        :return: the fraction of material a.
-        """
-        return self._fraction
-
-    @fraction.setter
-    def fraction(self, fraction: float) -> None:
-        """
-        Setter for fraction of material a.
-
-        :param fraction: double
-        """
-        if not isinstance(fraction, float):
-            raise ValueError('fraction must be a float')
-        self._fraction = fraction
+        self._fraction.raw_value = fraction
 
     @property
     def material_a(self) -> Material:
@@ -225,21 +204,13 @@ class MaterialMixture(BaseElement):
     def _update_name(self) -> None:
         self.name = self._material_a.name + '/' + self._material_b.name
 
-    # def _convert_to_dict(self, org_dict, _, **dont_care) -> dict:
-    #     org_dict['material_a'] = org_dict['_material_a']
-    #     del org_dict['_material_a']
-    #     org_dict['solvent_b'] = org_dict['_material_b']
-    #     del org_dict['_material_b']
-    #     org_dict['fraction'] = org_dict['_fraction']
-    #     del org_dict['_fraction']
-
     # Representation
     @property
     def _dict_repr(self) -> dict[str, str]:
         """A simplified dict representation."""
         return {
             self.name: {
-                'fraction': self._fraction.raw_value,
+                'fraction': f'{self._fraction.raw_value:.3f} {self._fraction.unit}',
                 'sld': f'{self._sld.raw_value:.3f}e-6 {self._sld.unit}',
                 'isld': f'{self._isld.raw_value:.3f}e-6 {self._isld.unit}',
                 'material_a': self._material_a._dict_repr,
@@ -248,14 +219,15 @@ class MaterialMixture(BaseElement):
         }
 
     def as_dict(self, skip: list = None) -> dict[str, str]:
-        """Custom as_dict method to skip necessary things."""
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
         if skip is None:
             skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['material_a'] = self._material_a
-        del this_dict['_material_a']
         this_dict['material_b'] = self._material_b
-        del this_dict['_material_b']
         this_dict['fraction'] = self._fraction
-        del this_dict['_fraction']
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -46,6 +46,25 @@ class MaterialMixture(BaseElement):
         :param name: Name of the material, defaults to None that causes the name to be constructed.
         :param interface: Calculator interface, defaults to `None`.
         """
+        sld = weighted_average(
+            a=material_a.sld.raw_value,
+            b=material_b.sld.raw_value,
+            p=fraction.raw_value,
+        )
+        isld = weighted_average(
+            a=material_a.isld.raw_value,
+            b=material_b.isld.raw_value,
+            p=fraction.raw_value,
+        )
+        default_options = deepcopy(MATERIAL_DEFAULTS)
+        del default_options['sld']['value']
+        del default_options['isld']['value']
+
+        self._sld = Parameter('sld', sld, **default_options['sld'])
+        self._isld = Parameter('isld', isld, **default_options['isld'])
+
+        # To avoid problems when setting the interface
+        # self._sld and self._isld need to be declared before calling the super constructor
         super().__init__(
             name,
             _material_a=material_a,
@@ -55,23 +74,6 @@ class MaterialMixture(BaseElement):
         )
         if name is None:
             self._update_name()
-
-        sld = weighted_average(
-            a=self._material_a.sld.raw_value,
-            b=self._material_b.sld.raw_value,
-            p=self._fraction.raw_value,
-        )
-        isld = weighted_average(
-            a=self._material_a.isld.raw_value,
-            b=self._material_b.isld.raw_value,
-            p=self._fraction.raw_value,
-        )
-        default_options = deepcopy(MATERIAL_DEFAULTS)
-        del default_options['sld']['value']
-        del default_options['isld']['value']
-
-        self._sld = Parameter('sld', sld, **default_options['sld'])
-        self._isld = Parameter('isld', isld, **default_options['isld'])
 
         self._materials_constraints()
         self.interface = interface
@@ -225,7 +227,7 @@ class MaterialMixture(BaseElement):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
-        this_dict['material_a'] = self._material_a
-        this_dict['material_b'] = self._material_b
-        this_dict['fraction'] = self._fraction
+        this_dict['material_a'] = self._material_a.as_dict()
+        this_dict['material_b'] = self._material_b.as_dict()
+        this_dict['fraction'] = self._fraction.as_dict()
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -8,7 +8,7 @@ from easyCore.Objects.ObjectClasses import Parameter
 
 from EasyReflectometry.special.calculations import weighted_average
 
-from ..base_element import BaseElement
+from ...base_core import BaseCore
 from .material import MATERIAL_DEFAULTS
 from .material import Material
 
@@ -24,7 +24,7 @@ MATERIALMIXTURE_DEFAULTS = {
 }
 
 
-class MaterialMixture(BaseElement):
+class MaterialMixture(BaseCore):
     # Added in super().__init__
     _material_a: Material
     _material_b: Material

--- a/EasyReflectometry/sample/elements/materials/material_mixture.py
+++ b/EasyReflectometry/sample/elements/materials/material_mixture.py
@@ -225,6 +225,14 @@ class MaterialMixture(BaseElement):
     def _update_name(self) -> None:
         self.name = self._material_a.name + '/' + self._material_b.name
 
+    # def _convert_to_dict(self, org_dict, _, **dont_care) -> dict:
+    #     org_dict['material_a'] = org_dict['_material_a']
+    #     del org_dict['_material_a']
+    #     org_dict['solvent_b'] = org_dict['_material_b']
+    #     del org_dict['_material_b']
+    #     org_dict['fraction'] = org_dict['_fraction']
+    #     del org_dict['_fraction']
+
     # Representation
     @property
     def _dict_repr(self) -> dict[str, str]:
@@ -245,5 +253,9 @@ class MaterialMixture(BaseElement):
             skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['material_a'] = self._material_a
+        del this_dict['_material_a']
         this_dict['material_b'] = self._material_b
+        del this_dict['_material_b']
+        this_dict['fraction'] = self._fraction
+        del this_dict['_fraction']
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_solvated.py
+++ b/EasyReflectometry/sample/elements/materials/material_solvated.py
@@ -120,7 +120,7 @@ class MaterialSolvated(MaterialMixture):
         self.material_b = new_solvent
 
     @property
-    def solvent_fraction(self) -> Parameter:
+    def solvent_fraction(self) -> float:
         """Get the fraction of layer described by the solvent.
         This might be fraction of:
         Solvation where solvent is within the layer
@@ -147,21 +147,13 @@ class MaterialSolvated(MaterialMixture):
     def _update_name(self) -> None:
         self.name = self._material_a.name + ' in ' + self._material_b.name
 
-    # def _convert_to_dict(self, org_dict, _, **dont_care) -> dict:
-    #     org_dict['material'] = org_dict['_material_a']
-    #     del org_dict['_material_a']
-    #     org_dict['solvent'] = org_dict['_material_b']
-    #     del org_dict['_material_b']
-    #     org_dict['fraction'] = org_dict['_fraction']
-    #     del org_dict['_fraction']
-
     # Representation
     @property
     def _dict_repr(self) -> dict[str, str]:
         """A simplified dict representation."""
         return {
             self.name: {
-                'solvent_fraction': self.solvent_fraction.raw_value,
+                'solvent_fraction': f'{self._fraction.raw_value:.3f} {self._fraction.unit}',
                 'sld': f'{self._sld.raw_value:.3f}e-6 {self._sld.unit}',
                 'isld': f'{self._isld.raw_value:.3f}e-6 {self._isld.unit}',
                 'material': self.material._dict_repr,
@@ -170,12 +162,21 @@ class MaterialSolvated(MaterialMixture):
         }
 
     def as_dict(self, skip: list = None) -> dict[str, str]:
-        """Custom as_dict method to skip necessary things."""
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
         if skip is None:
             skip = []
         this_dict = super().as_dict(skip=skip)
-        this_dict['material'] = self._material_a
+        this_dict['material'] = self.material
         del this_dict['material_a']
-        this_dict['solvent'] = self._material_b
+        del this_dict['_material_a']
+        this_dict['solvent'] = self.solvent
         del this_dict['material_b']
+        del this_dict['_material_b']
+        this_dict['solvent_fraction'] = self._fraction
+        del this_dict['fraction']
+        del this_dict['_fraction']
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_solvated.py
+++ b/EasyReflectometry/sample/elements/materials/material_solvated.py
@@ -168,9 +168,9 @@ class MaterialSolvated(MaterialMixture):
         :param skip: List of keys to skip, defaults to `None`.
         """
         this_dict = super().as_dict(skip=skip)
-        this_dict['material'] = self.material
-        this_dict['solvent'] = self.solvent
-        this_dict['solvent_fraction'] = self._fraction
+        this_dict['material'] = self.material.as_dict()
+        this_dict['solvent'] = self.solvent.as_dict()
+        this_dict['solvent_fraction'] = self._fraction.as_dict()
         # Property and protected varible from material_mixture
         del this_dict['material_a']
         del this_dict['_material_a']

--- a/EasyReflectometry/sample/elements/materials/material_solvated.py
+++ b/EasyReflectometry/sample/elements/materials/material_solvated.py
@@ -147,6 +147,14 @@ class MaterialSolvated(MaterialMixture):
     def _update_name(self) -> None:
         self.name = self._material_a.name + ' in ' + self._material_b.name
 
+    # def _convert_to_dict(self, org_dict, _, **dont_care) -> dict:
+    #     org_dict['material'] = org_dict['_material_a']
+    #     del org_dict['_material_a']
+    #     org_dict['solvent'] = org_dict['_material_b']
+    #     del org_dict['_material_b']
+    #     org_dict['fraction'] = org_dict['_fraction']
+    #     del org_dict['_fraction']
+
     # Representation
     @property
     def _dict_repr(self) -> dict[str, str]:
@@ -160,3 +168,14 @@ class MaterialSolvated(MaterialMixture):
                 'solvent': self.solvent._dict_repr,
             }
         }
+
+    def as_dict(self, skip: list = None) -> dict[str, str]:
+        """Custom as_dict method to skip necessary things."""
+        if skip is None:
+            skip = []
+        this_dict = super().as_dict(skip=skip)
+        this_dict['material'] = self._material_a
+        del this_dict['material_a']
+        this_dict['solvent'] = self._material_b
+        del this_dict['material_b']
+        return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_solvated.py
+++ b/EasyReflectometry/sample/elements/materials/material_solvated.py
@@ -169,12 +169,15 @@ class MaterialSolvated(MaterialMixture):
         """
         this_dict = super().as_dict(skip=skip)
         this_dict['material'] = self.material
+        this_dict['solvent'] = self.solvent
+        this_dict['solvent_fraction'] = self._fraction
+        # Property and protected varible from material_mixture
         del this_dict['material_a']
         del this_dict['_material_a']
-        this_dict['solvent'] = self.solvent
+        # Property and protected varible from material_mixture
         del this_dict['material_b']
         del this_dict['_material_b']
-        this_dict['solvent_fraction'] = self._fraction
+        # Property and protected varible from material_mixture
         del this_dict['fraction']
         del this_dict['_fraction']
         return this_dict

--- a/EasyReflectometry/sample/elements/materials/material_solvated.py
+++ b/EasyReflectometry/sample/elements/materials/material_solvated.py
@@ -167,8 +167,6 @@ class MaterialSolvated(MaterialMixture):
 
         :param skip: List of keys to skip, defaults to `None`.
         """
-        if skip is None:
-            skip = []
         this_dict = super().as_dict(skip=skip)
         this_dict['material'] = self.material
         del this_dict['material_a']

--- a/EasyReflectometry/sample/sample.py
+++ b/EasyReflectometry/sample/sample.py
@@ -76,5 +76,18 @@ class Sample(BaseCollection):
         return {self.name: [i._dict_repr for i in self]}
 
     def __repr__(self) -> str:
-        """String representation of the layer."""
+        """String representation of the sample."""
         return yaml.dump(self._dict_repr, sort_keys=False)
+
+    def as_dict(self, skip: list = None) -> dict:
+        """Produces a cleaned dict using a custom as_dict method to skip necessary things.
+        The resulting dict matches the paramters in __init__
+
+        :param skip: List of keys to skip, defaults to `None`.
+        """
+        if skip is None:
+            skip = []
+        this_dict = super().as_dict(skip=skip)
+        for i, layer in enumerate(self.data):
+            this_dict['data'][i] = layer.as_dict()
+        return this_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "EasyReflectometryLib"
-version = "0.0.5"
+version = "0.0.5-dev"
 description = "A reflectometry python package built on the EasyScience framework."
 readme = "README.rst"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "EasyReflectometryLib"
-version = "0.0.5-dev"
+version = "0.0.5"
 description = "A reflectometry python package built on the EasyScience framework."
 readme = "README.rst"
 authors = [

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -9,6 +9,7 @@ __version__ = '0.0.1'
 import unittest
 
 import numpy as np
+import pytest
 from numpy.testing import assert_equal
 
 from EasyReflectometry.calculators import CalculatorFactory
@@ -16,8 +17,10 @@ from EasyReflectometry.experiment.model import Model
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
 from EasyReflectometry.sample import Material
+from EasyReflectometry.sample import Multilayer
 from EasyReflectometry.sample import RepeatingMultilayer
 from EasyReflectometry.sample import Sample
+from EasyReflectometry.sample import SurfactantLayer
 
 
 class TestModel(unittest.TestCase):
@@ -87,6 +90,8 @@ class TestModel(unittest.TestCase):
         ls2 = LayerCollection.from_pars(l2, l1, name='twoLayer2')
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
+        surfactant = SurfactantLayer.default()
+        multilayer = Multilayer.default()
         d = Sample.from_pars(o1, name='myModel')
         mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel')
         assert_equal(len(mod.sample), 1)
@@ -94,6 +99,18 @@ class TestModel(unittest.TestCase):
         assert_equal(len(mod.sample), 2)
         assert_equal(mod.sample[1].name, 'oneLayerItem2')
         assert_equal(issubclass(mod.sample[1].__class__, RepeatingMultilayer), True)
+        mod.add_item(surfactant)
+        assert_equal(len(mod.sample), 3)
+        mod.add_item(multilayer)
+        assert_equal(len(mod.sample), 4)
+
+    def test_add_item_exception(self):
+        # When
+        mod = Model.default()
+
+        # Then Expect
+        with pytest.raises(ValueError):
+            mod.add_item('not an assembly')
 
     def test_add_item_with_interface_refnx(self):
         interface = CalculatorFactory()

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -337,12 +337,14 @@ class TestModel(unittest.TestCase):
         )
 
     def test_dict_round_trip(self):
-        p = Model.default()
+        interface = CalculatorFactory()
+        p = Model.default(interface)
         surfactant = SurfactantLayer.default()
         p.add_item(surfactant)
         multilayer = Multilayer.default()
         p.add_item(multilayer)
         repeating = RepeatingMultilayer.default()
         p.add_item(repeating)
-        q = Model.from_dict(p.as_dict())
+        src_dict = p.as_dict()
+        q = Model.from_dict(src_dict)
         assert p.as_data_dict() == q.as_data_dict()

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -338,5 +338,11 @@ class TestModel(unittest.TestCase):
 
     def test_dict_round_trip(self):
         p = Model.default()
+        surfactant = SurfactantLayer.default()
+        p.add_item(surfactant)
+        multilayer = Multilayer.default()
+        p.add_item(multilayer)
+        repeating = RepeatingMultilayer.default()
+        p.add_item(repeating)
         q = Model.from_dict(p.as_dict())
         assert p.as_data_dict() == q.as_data_dict()

--- a/tests/sample/assemblies/test_gradient_layer.py
+++ b/tests/sample/assemblies/test_gradient_layer.py
@@ -1,6 +1,7 @@
 """
 Tests for GradientLayer class module
 """
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -178,3 +179,9 @@ def test_prepare_gradient_layers(monkeypatch):
     assert mock_Layer.from_pars.call_args_list[0][1]['thickness'] == 0.0
     assert mock_Layer.from_pars.call_args_list[0][1]['name'] == '0'
     assert mock_Layer.from_pars.call_args_list[0][1]['interface'] is None
+
+
+def test_dict_round_trip():
+    p = GradientLayer.default()
+    q = GradientLayer.from_dict(p.as_dict())
+    assert p.as_data_dict() == q.as_data_dict()

--- a/tests/sample/assemblies/test_multilayer.py
+++ b/tests/sample/assemblies/test_multilayer.py
@@ -1,6 +1,7 @@
 """
 Tests for MultiLayer class module
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -11,8 +12,8 @@ from numpy.testing import assert_raises
 
 from EasyReflectometry.calculators.factory import CalculatorFactory
 from EasyReflectometry.sample.assemblies.multilayer import Multilayer
-from EasyReflectometry.sample.elements.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.layers.layer import Layer
+from EasyReflectometry.sample.elements.layers.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.materials.material import Material
 
 

--- a/tests/sample/assemblies/test_repeating_multilayer.py
+++ b/tests/sample/assemblies/test_repeating_multilayer.py
@@ -13,8 +13,8 @@ from numpy.testing import assert_raises
 
 from EasyReflectometry.calculators import CalculatorFactory
 from EasyReflectometry.sample.assemblies.repeating_multilayer import RepeatingMultilayer
-from EasyReflectometry.sample.elements.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.layers.layer import Layer
+from EasyReflectometry.sample.elements.layers.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.materials.material import Material
 
 

--- a/tests/sample/assemblies/test_surfactant_layer.py
+++ b/tests/sample/assemblies/test_surfactant_layer.py
@@ -1,6 +1,7 @@
 """
 Tests for SurfactantLayer class module
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -37,31 +38,31 @@ class TestSurfactantLayer(unittest.TestCase):
         assert p.tail_layer.molecular_formula == 'C8O10H12P'
         assert p.tail_layer.thickness.raw_value == 12
         assert p.tail_layer.solvent.as_data_dict() == h2o.as_data_dict()
-        assert p.tail_layer.solvent_fraction.raw_value == 0.5
-        assert p.tail_layer.area_per_molecule.raw_value == 50
+        assert p.tail_layer.solvent_fraction == 0.5
+        assert p.tail_layer.area_per_molecule == 50
         assert p.tail_layer.roughness.raw_value == 2
         assert p.layers[1].name == 'A Test Head Layer'
         assert p.head_layer.name == 'A Test Head Layer'
         assert p.head_layer.molecular_formula == 'C10H24'
         assert p.head_layer.thickness.raw_value == 10
         assert p.head_layer.solvent.as_data_dict() == noth2o.as_data_dict()
-        assert p.head_layer.solvent_fraction.raw_value == 0.2
-        assert p.head_layer.area_per_molecule.raw_value == 40
+        assert p.head_layer.solvent_fraction == 0.2
+        assert p.head_layer.area_per_molecule == 40
         assert p.name == 'A Test'
 
     def test_constraint_area_per_molecule(self):
         p = SurfactantLayer.default()
-        p.tail_layer.area_per_molecule.value = 30
-        assert p.tail_layer.area_per_molecule.raw_value == 30.0
-        assert p.head_layer.area_per_molecule.raw_value == 48.2
+        p.tail_layer._area_per_molecule.value = 30
+        assert p.tail_layer.area_per_molecule == 30.0
+        assert p.head_layer.area_per_molecule == 48.2
         assert p.constrain_area_per_molecule is False
         p.constrain_area_per_molecule = True
-        assert p.tail_layer.area_per_molecule.raw_value == 30
-        assert p.head_layer.area_per_molecule.raw_value == 30
+        assert p.tail_layer.area_per_molecule == 30
+        assert p.head_layer.area_per_molecule == 30
         assert p.constrain_area_per_molecule is True
-        p.tail_layer.area_per_molecule.value = 40
-        assert p.tail_layer.area_per_molecule.raw_value == 40
-        assert p.head_layer.area_per_molecule.raw_value == 40
+        p.tail_layer._area_per_molecule.value = 40
+        assert p.tail_layer.area_per_molecule == 40
+        assert p.head_layer.area_per_molecule == 40
 
     def test_conformal_roughness(self):
         p = SurfactantLayer.default()
@@ -101,7 +102,7 @@ class TestSurfactantLayer(unittest.TestCase):
                 'DPPC Head': {
                     'material': {
                         'C10H18NO8P in D2O': {
-                            'solvent_fraction': 0.2,
+                            'solvent_fraction': '0.200 dimensionless',
                             'sld': '2.269e-6 1 / angstrom ** 2',
                             'isld': '0.000e-6 1 / angstrom ** 2',
                             'material': {
@@ -120,7 +121,7 @@ class TestSurfactantLayer(unittest.TestCase):
                 'DPPC Tail': {
                     'material': {
                         'C32D64 in Air': {
-                            'solvent_fraction': 0.0,
+                            'solvent_fraction': '0.000 dimensionless',
                             'sld': '8.297e-6 1 / angstrom ** 2',
                             'isld': '0.000e-6 1 / angstrom ** 2',
                             'material': {

--- a/tests/sample/assemblies/test_surfactant_layer.py
+++ b/tests/sample/assemblies/test_surfactant_layer.py
@@ -16,7 +16,7 @@ from EasyReflectometry.sample.elements.materials.material import Material
 class TestSurfactantLayer(unittest.TestCase):
     def test_default(self):
         p = SurfactantLayer.default()
-        assert p.name == 'DPPC'
+        assert p.name == 'EasySurfactantLayer'
         assert p._type == 'Surfactant Layer'
 
         assert p.layers[0].name == 'DPPC Tail'
@@ -98,46 +98,52 @@ class TestSurfactantLayer(unittest.TestCase):
     def test_dict_repr(self):
         p = SurfactantLayer.default()
         assert p._dict_repr == {
-            'head_layer': {
-                'DPPC Head': {
-                    'material': {
-                        'C10H18NO8P in D2O': {
-                            'solvent_fraction': '0.200 dimensionless',
-                            'sld': '2.269e-6 1 / angstrom ** 2',
-                            'isld': '0.000e-6 1 / angstrom ** 2',
-                            'material': {
-                                'C10H18NO8P': {'sld': '1.246e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
-                            },
-                            'solvent': {'D2O': {'sld': '6.360e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
-                        }
+            'EasySurfactantLayer': {
+                'head_layer': {
+                    'DPPC Head': {
+                        'material': {
+                            'C10H18NO8P in D2O': {
+                                'solvent_fraction': '0.200 dimensionless',
+                                'sld': '2.269e-6 1 / angstrom ** 2',
+                                'isld': '0.000e-6 1 / angstrom ** 2',
+                                'material': {
+                                    'C10H18NO8P': {'sld': '1.246e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
+                                },
+                                'solvent': {
+                                    'D2O': {'sld': '6.360e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
+                                },
+                            }
+                        },
+                        'thickness': '10.000 angstrom',
+                        'roughness': '3.000 angstrom',
                     },
-                    'thickness': '10.000 angstrom',
-                    'roughness': '3.000 angstrom',
+                    'molecular_formula': 'C10H18NO8P',
+                    'area_per_molecule': '48.20 angstrom ** 2',
                 },
-                'molecular_formula': 'C10H18NO8P',
-                'area_per_molecule': '48.20 angstrom ** 2',
-            },
-            'tail_layer': {
-                'DPPC Tail': {
-                    'material': {
-                        'C32D64 in Air': {
-                            'solvent_fraction': '0.000 dimensionless',
-                            'sld': '8.297e-6 1 / angstrom ** 2',
-                            'isld': '0.000e-6 1 / angstrom ** 2',
-                            'material': {
-                                'C32D64': {'sld': '8.297e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
-                            },
-                            'solvent': {'Air': {'sld': '0.000e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
-                        }
+                'tail_layer': {
+                    'DPPC Tail': {
+                        'material': {
+                            'C32D64 in Air': {
+                                'solvent_fraction': '0.000 dimensionless',
+                                'sld': '8.297e-6 1 / angstrom ** 2',
+                                'isld': '0.000e-6 1 / angstrom ** 2',
+                                'material': {
+                                    'C32D64': {'sld': '8.297e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
+                                },
+                                'solvent': {
+                                    'Air': {'sld': '0.000e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}
+                                },
+                            }
+                        },
+                        'thickness': '16.000 angstrom',
+                        'roughness': '3.000 angstrom',
                     },
-                    'thickness': '16.000 angstrom',
-                    'roughness': '3.000 angstrom',
+                    'molecular_formula': 'C32D64',
+                    'area_per_molecule': '48.20 angstrom ** 2',
                 },
-                'molecular_formula': 'C32D64',
-                'area_per_molecule': '48.20 angstrom ** 2',
-            },
-            'area per molecule constrained': False,
-            'conformal roughness': False,
+                'area per molecule constrained': False,
+                'conformal roughness': False,
+            }
         }
 
     def test_get_head_layer(self):

--- a/tests/sample/elements/layers/test_layer_area_per_molecule.py
+++ b/tests/sample/elements/layers/test_layer_area_per_molecule.py
@@ -1,6 +1,7 @@
 """
 Tests for LayerAreaPerMolecule class.
 """
+
 import unittest
 
 from numpy.testing import assert_almost_equal
@@ -13,24 +14,24 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
     def test_default(self):
         p = LayerAreaPerMolecule.default()
         assert p.molecular_formula == 'C10H18NO8P'
-        assert p.area_per_molecule.raw_value == 48.2
-        assert str(p.area_per_molecule.unit) == 'angstrom ** 2'
-        assert p.area_per_molecule.fixed is True
+        assert p.area_per_molecule == 48.2
+        assert str(p._area_per_molecule.unit) == 'angstrom ** 2'
+        assert p._area_per_molecule.fixed is True
         assert p.thickness.raw_value == 10.0
         assert str(p.thickness.unit) == 'angstrom'
         assert p.thickness.fixed is True
         assert p.roughness.raw_value == 3.3
         assert str(p.roughness.unit) == 'angstrom'
         assert p.roughness.fixed is True
-        assert_almost_equal(p.material.sld.raw_value, 2.2691419)
-        assert_almost_equal(p.material.isld.raw_value, 0)
+        assert_almost_equal(p.material.sld, 2.2691419)
+        assert_almost_equal(p.material.isld, 0)
         assert p.material.name == 'C10H18NO8P in D2O'
         assert p.solvent.sld.raw_value == 6.36
         assert p.solvent.isld.raw_value == 0
         assert p.solvent.name == 'D2O'
-        assert p.solvent_fraction.raw_value == 0.2
-        assert str(p.solvent_fraction.unit) == 'dimensionless'
-        assert p.solvent_fraction.fixed is True
+        assert p.solvent_fraction == 0.2
+        assert str(p.material._fraction.unit) == 'dimensionless'
+        assert p.material._fraction.fixed is True
 
     def test_from_pars(self):
         h2o = Material.from_pars(-0.561, 0, 'H2O')
@@ -44,12 +45,12 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
             name='PG/H2O',
         )
         assert p.molecular_formula == 'C8O10H12P'
-        assert p.area_per_molecule.raw_value == 50
+        assert p.area_per_molecule == 50
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
         assert p.solvent.sld.raw_value == -0.561
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
+        assert p.solvent_fraction == 0.5
 
     def test_from_pars_constraint(self):
         h2o = Material.from_pars(-0.561, 0, 'H2O')
@@ -63,19 +64,19 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
             name='PG/H2O',
         )
         assert p.molecular_formula == 'C8O10H12P'
-        assert p.area_per_molecule.raw_value == 50
-        assert_almost_equal(p.material.sld.raw_value, 0.31513666667)
+        assert p.area_per_molecule == 50
+        assert_almost_equal(p.material.sld, 0.31513666667)
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
         assert p.solvent.sld.raw_value == -0.561
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
-        p.area_per_molecule.value = 30
-        assert p.area_per_molecule.raw_value == 30
-        assert_almost_equal(p.material.sld.raw_value, 0.712227778)
+        assert p.solvent_fraction == 0.5
+        p.area_per_molecule = 30
+        assert p.area_per_molecule == 30
+        assert_almost_equal(p.material.sld, 0.712227778)
         p.thickness.value = 10
         assert p.thickness.raw_value == 10
-        assert_almost_equal(p.material.sld.raw_value, 0.910773333)
+        assert_almost_equal(p.material.sld, 0.910773333)
 
     def test_solvent_change(self):
         h2o = Material.from_pars(-0.561, 0, 'H2O')
@@ -89,24 +90,24 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
             name='PG/H2O',
         )
         assert p.molecular_formula == 'C8O10H12P'
-        assert p.area_per_molecule.raw_value == 50
+        assert p.area_per_molecule == 50
         print(p.material)
-        assert_almost_equal(p.material.sld.raw_value, 0.31513666667)
+        assert_almost_equal(p.material.sld, 0.31513666667)
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
         assert p.solvent.sld.raw_value == -0.561
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
+        assert p.solvent_fraction == 0.5
         d2o = Material.from_pars(6.335, 0, 'D2O')
         p.solvent = d2o
         assert p.molecular_formula == 'C8O10H12P'
-        assert p.area_per_molecule.raw_value == 50
-        assert_almost_equal(p.material.sld.raw_value, 3.7631366667)
+        assert p.area_per_molecule == 50
+        assert_almost_equal(p.material.sld, 3.7631366667)
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
         assert p.solvent.sld.raw_value == 6.335
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
+        assert p.solvent_fraction == 0.5
 
     def test_molecular_formula_change(self):
         h2o = Material.from_pars(-0.561, 0, 'H2O')
@@ -120,24 +121,24 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
             name='PG/H2O',
         )
         assert p.molecular_formula == 'C8O10H12P'
-        assert p.area_per_molecule.raw_value == 50
-        assert_almost_equal(p.material.sld.raw_value, 0.31513666667)
+        assert p.area_per_molecule == 50
+        assert_almost_equal(p.material.sld, 0.31513666667)
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
 
         assert p.solvent.sld.raw_value == -0.561
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
+        assert p.solvent_fraction == 0.5
         assert p.material.name == 'C8O10H12P in H2O'
         p.molecular_formula = 'C8O10D12P'
         assert p.molecular_formula == 'C8O10D12P'
-        assert p.area_per_molecule.raw_value == 50
-        assert_almost_equal(p.material.sld.raw_value, 1.3566266666666666)
+        assert p.area_per_molecule == 50
+        assert_almost_equal(p.material.sld, 1.3566266666666666)
         assert p.thickness.raw_value == 12
         assert p.roughness.raw_value == 2
         assert p.solvent.sld.raw_value == -0.561
         assert p.solvent.isld.raw_value == 0
-        assert p.solvent_fraction.raw_value == 0.5
+        assert p.solvent_fraction == 0.5
         assert p.material.name == 'C8O10D12P in H2O'
 
     def test_dict_repr(self):
@@ -146,7 +147,7 @@ class TestLayerAreaPerMolecule(unittest.TestCase):
             'EasyLayerAreaPerMolecule': {
                 'material': {
                     'C10H18NO8P in D2O': {
-                        'solvent_fraction': 0.2,
+                        'solvent_fraction': '0.200 dimensionless',
                         'sld': '2.269e-6 1 / angstrom ** 2',
                         'isld': '0.000e-6 1 / angstrom ** 2',
                         'material': {

--- a/tests/sample/elements/materials/test_material_mixture.py
+++ b/tests/sample/elements/materials/test_material_mixture.py
@@ -8,7 +8,6 @@ from EasyReflectometry.sample.elements.materials.material_mixture import Materia
 
 
 class TestMaterialMixture(unittest.TestCase):
-
     def test_default(self):
         p = MaterialMixture.default()
         assert p._fraction.raw_value == 0.5
@@ -30,7 +29,7 @@ class TestMaterialMixture(unittest.TestCase):
         assert_almost_equal(p.isld.raw_value, -0.5)
         assert str(p.sld.unit) == '1 / angstrom ** 2'
         assert str(p.isld.unit) == '1 / angstrom ** 2'
-    
+
     def test_fraction_constraint(self):
         p = Material.default()
         q = Material.from_pars(6.908, -0.278, 'Boron')
@@ -108,18 +107,8 @@ class TestMaterialMixture(unittest.TestCase):
                 'fraction': 0.5,
                 'sld': '4.186e-6 1 / angstrom ** 2',
                 'isld': '0.000e-6 1 / angstrom ** 2',
-                'material_a': {
-                    'EasyMaterial': {
-                        'sld': '4.186e-6 1 / angstrom ** 2',
-                        'isld': '0.000e-6 1 / angstrom ** 2'
-                    }
-                },
-                'material_b': {
-                    'EasyMaterial': {
-                        'sld': '4.186e-6 1 / angstrom ** 2',
-                        'isld': '0.000e-6 1 / angstrom ** 2'
-                    }
-                }
+                'material_a': {'EasyMaterial': {'sld': '4.186e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
+                'material_b': {'EasyMaterial': {'sld': '4.186e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
             }
         }
 
@@ -127,7 +116,7 @@ class TestMaterialMixture(unittest.TestCase):
         p = MaterialMixture.default()
         q = MaterialMixture.from_dict(p.as_dict())
         assert p.as_data_dict() == q.as_data_dict()
-    
+
     def test_update_name(self):
         # When
         p = MaterialMixture.default()

--- a/tests/sample/elements/materials/test_material_mixture.py
+++ b/tests/sample/elements/materials/test_material_mixture.py
@@ -10,101 +10,101 @@ from EasyReflectometry.sample.elements.materials.material_mixture import Materia
 class TestMaterialMixture(unittest.TestCase):
     def test_default(self):
         p = MaterialMixture.default()
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert p.sld.raw_value == Material.default().sld.raw_value
-        assert p.isld.raw_value == Material.default().isld.raw_value
-        assert str(p.sld.unit) == '1 / angstrom ** 2'
-        assert str(p.isld.unit) == '1 / angstrom ** 2'
+        assert p.sld == Material.default().sld.raw_value
+        assert p.isld == Material.default().isld.raw_value
+        assert str(p._sld.unit) == '1 / angstrom ** 2'
+        assert str(p._isld.unit) == '1 / angstrom ** 2'
 
     def test_default_constraint(self):
         p = MaterialMixture.default()
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert p.sld.raw_value == Material.default().sld.raw_value
-        assert p.isld.raw_value == Material.default().isld.raw_value
+        assert p.sld == Material.default().sld.raw_value
+        assert p.isld == Material.default().isld.raw_value
         p.material_a.sld.value = 0
         p.material_b.isld.value = -1
-        assert_almost_equal(p.sld.raw_value, 2.093)
-        assert_almost_equal(p.isld.raw_value, -0.5)
-        assert str(p.sld.unit) == '1 / angstrom ** 2'
-        assert str(p.isld.unit) == '1 / angstrom ** 2'
+        assert_almost_equal(p.sld, 2.093)
+        assert_almost_equal(p.isld, -0.5)
+        assert str(p._sld.unit) == '1 / angstrom ** 2'
+        assert str(p._isld.unit) == '1 / angstrom ** 2'
 
     def test_fraction_constraint(self):
         p = Material.default()
         q = Material.from_pars(6.908, -0.278, 'Boron')
         r = MaterialMixture.from_pars(p, q, 0.2)
-        assert r._fraction.raw_value == 0.2
-        assert_almost_equal(r.sld.raw_value, 4.7304)
-        assert_almost_equal(r.isld.raw_value, -0.0556)
+        assert r.fraction == 0.2
+        assert_almost_equal(r.sld, 4.7304)
+        assert_almost_equal(r.isld, -0.0556)
         r._fraction.value = 0.5
-        assert r._fraction.raw_value == 0.5
-        assert_almost_equal(r.sld.raw_value, 5.54700)
-        assert_almost_equal(r.isld.raw_value, -0.1390)
+        assert r.fraction == 0.5
+        assert_almost_equal(r.sld, 5.54700)
+        assert_almost_equal(r.isld, -0.1390)
 
     def test_material_a_change(self):
         p = MaterialMixture.default()
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert p.sld.raw_value == Material.default().sld.raw_value
-        assert p.isld.raw_value == Material.default().isld.raw_value
+        assert p.sld == Material.default().sld.raw_value
+        assert p.isld == Material.default().isld.raw_value
         q = Material.from_pars(6.908, -0.278, 'Boron')
         p.material_a = q
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert_almost_equal(p.sld.raw_value, 5.54700)
-        assert_almost_equal(p.isld.raw_value, -0.1390)
+        assert_almost_equal(p.sld, 5.54700)
+        assert_almost_equal(p.isld, -0.1390)
 
     def test_material_b_change(self):
         p = MaterialMixture.default()
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert p.sld.raw_value == Material.default().sld.raw_value
-        assert p.isld.raw_value == Material.default().isld.raw_value
+        assert p.sld == Material.default().sld.raw_value
+        assert p.isld == Material.default().isld.raw_value
         q = Material.from_pars(6.908, -0.278, 'Boron')
         p.material_b = q
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert_almost_equal(p.sld.raw_value, 5.54700)
-        assert_almost_equal(p.isld.raw_value, -0.1390)
+        assert_almost_equal(p.sld, 5.54700)
+        assert_almost_equal(p.isld, -0.1390)
 
     def test_material_b_change_double(self):
         p = MaterialMixture.default()
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert p.sld.raw_value == Material.default().sld.raw_value
-        assert p.isld.raw_value == Material.default().isld.raw_value
+        assert p.sld == Material.default().sld.raw_value
+        assert p.isld == Material.default().isld.raw_value
         q = Material.from_pars(6.908, -0.278, 'Boron')
         p.material_b = q
         assert p.name == 'EasyMaterial/Boron'
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert_almost_equal(p.sld.raw_value, 5.54700)
-        assert_almost_equal(p.isld.raw_value, -0.1390)
+        assert_almost_equal(p.sld, 5.54700)
+        assert_almost_equal(p.isld, -0.1390)
         r = Material.from_pars(0.00, 0.00, 'ACMW')
         p.material_b = r
         assert p.name == 'EasyMaterial/ACMW'
-        assert p._fraction.raw_value == 0.5
+        assert p.fraction == 0.5
         assert str(p._fraction.unit) == 'dimensionless'
-        assert_almost_equal(p.sld.raw_value, 2.0930)
-        assert_almost_equal(p.isld.raw_value, 0.0000)
+        assert_almost_equal(p.sld, 2.0930)
+        assert_almost_equal(p.isld, 0.0000)
 
     def test_from_pars(self):
         p = Material.default()
         q = Material.from_pars(6.908, -0.278, 'Boron')
         r = MaterialMixture.from_pars(p, q, 0.2)
-        assert r._fraction.raw_value == 0.2
+        assert r.fraction == 0.2
         assert str(r._fraction.unit) == 'dimensionless'
-        assert_almost_equal(r.sld.raw_value, 4.7304)
-        assert_almost_equal(r.isld.raw_value, -0.0556)
-        assert str(r.sld.unit) == '1 / angstrom ** 2'
-        assert str(r.isld.unit) == '1 / angstrom ** 2'
+        assert_almost_equal(r.sld, 4.7304)
+        assert_almost_equal(r.isld, -0.0556)
+        assert str(r._sld.unit) == '1 / angstrom ** 2'
+        assert str(r._isld.unit) == '1 / angstrom ** 2'
 
     def test_dict_repr(self):
         p = MaterialMixture.default()
         assert p._dict_repr == {
             'EasyMaterial/EasyMaterial': {
-                'fraction': 0.5,
+                'fraction': '0.500 dimensionless',
                 'sld': '4.186e-6 1 / angstrom ** 2',
                 'isld': '0.000e-6 1 / angstrom ** 2',
                 'material_a': {'EasyMaterial': {'sld': '4.186e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},

--- a/tests/sample/elements/materials/test_material_solvated.py
+++ b/tests/sample/elements/materials/test_material_solvated.py
@@ -37,7 +37,7 @@ class TestMaterialSolvated:
         # When Then Expect
         assert material_solvated.material_a == self.mock_material
         assert material_solvated.material_b == self.mock_solvent
-        assert material_solvated.fraction == self.mock_solvent_fraction
+        assert material_solvated.fraction == 0.1
         assert material_solvated.name == 'name'
         assert material_solvated.interface == self.mock_interface
         self.mock_interface.generate_bindings.call_count == 2
@@ -76,7 +76,7 @@ class TestMaterialSolvated:
 
     def test_solvent_fraction(self, material_solvated: MaterialSolvated) -> None:
         # When Then Expect
-        assert material_solvated.solvent_fraction == self.mock_solvent_fraction
+        assert material_solvated.solvent_fraction == 0.1
 
     def test_set_solvent_fraction(self, material_solvated: MaterialSolvated) -> None:
         # When Then
@@ -102,28 +102,25 @@ class TestMaterialSolvated:
         # When Then Expect (no exception)
         material_solvated.solvent_fraction = 1.0
 
-    def test_dict_repr(self, material_solvated: MaterialSolvated) -> None:
+    def test_dict_repr(self) -> None:
         # When Then
-        material_solvated._sld = MagicMock()
-        material_solvated._sld.raw_value = 1.0
-        material_solvated._sld.unit = 'sld_unit'
-        material_solvated._isld = MagicMock()
-        material_solvated._isld.raw_value = 2.0
-        material_solvated._isld.unit = 'isld_unit'
-        material_solvated.material._dict_repr = 'material_dict_repr'
-        material_solvated.solvent._dict_repr = 'solvent_dict_repr'
-        material_solvated.solvent_fraction.raw_value = 'solvent_fraction_value'
+        p = MaterialSolvated.default()
 
         # Expect
-        assert material_solvated._dict_repr == {
-            'name': {
-                'solvent_fraction': 'solvent_fraction_value',
-                'sld': '1.000e-6 sld_unit',
-                'isld': '2.000e-6 isld_unit',
-                'material': 'material_dict_repr',
-                'solvent': 'solvent_dict_repr',
+        assert p._dict_repr == {
+            'D2O in H2O': {
+                'solvent_fraction': '0.200 dimensionless',
+                'sld': '4.976e-6 1 / angstrom ** 2',
+                'isld': '0.000e-6 1 / angstrom ** 2',
+                'material': {'D2O': {'sld': '6.360e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
+                'solvent': {'H2O': {'sld': '-0.561e-6 1 / angstrom ** 2', 'isld': '0.000e-6 1 / angstrom ** 2'}},
             }
         }
+
+    def test_dict_round_trip(self):
+        p = MaterialSolvated.default()
+        q = MaterialSolvated.from_dict(p.as_dict())
+        assert p.as_data_dict() == q.as_data_dict()
 
     def test_update_name(self, material_solvated: MaterialSolvated) -> None:
         # When

--- a/tests/sample/elements/test_layer_collection.py
+++ b/tests/sample/elements/test_layer_collection.py
@@ -1,6 +1,7 @@
 """
 Tests for LayerCollection class.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -9,8 +10,8 @@ import unittest
 from numpy.testing import assert_equal
 
 from EasyReflectometry.sample.assemblies.repeating_multilayer import RepeatingMultilayer
-from EasyReflectometry.sample.elements.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.layers.layer import Layer
+from EasyReflectometry.sample.elements.layers.layer_collection import LayerCollection
 from EasyReflectometry.sample.elements.materials.material import Material
 
 

--- a/tests/sample/elements/test_material_collection.py
+++ b/tests/sample/elements/test_material_collection.py
@@ -1,13 +1,14 @@
 """
 Tests for LayerCollection class.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
 import unittest
 
-from EasyReflectometry.sample.elements.material_collection import MaterialCollection
 from EasyReflectometry.sample.elements.materials.material import Material
+from EasyReflectometry.sample.elements.materials.material_collection import MaterialCollection
 
 
 class TestLayerCollection(unittest.TestCase):

--- a/tests/sample/test_sample.py
+++ b/tests/sample/test_sample.py
@@ -1,6 +1,7 @@
 """
 Tests for Sample class.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -8,11 +9,13 @@ import unittest
 
 from numpy.testing import assert_equal
 
-from EasyReflectometry.sample.assemblies.repeating_multilayer import RepeatingMultilayer
-from EasyReflectometry.sample.elements.layer_collection import LayerCollection
-from EasyReflectometry.sample.elements.layers.layer import Layer
-from EasyReflectometry.sample.elements.materials.material import Material
-from EasyReflectometry.sample.sample import Sample
+from EasyReflectometry.sample import Layer
+from EasyReflectometry.sample import LayerCollection
+from EasyReflectometry.sample import Material
+from EasyReflectometry.sample import Multilayer
+from EasyReflectometry.sample import RepeatingMultilayer
+from EasyReflectometry.sample import Sample
+from EasyReflectometry.sample import SurfactantLayer
 
 
 class TestSample(unittest.TestCase):
@@ -63,5 +66,12 @@ class TestSample(unittest.TestCase):
 
     def test_dict_round_trip(self):
         p = Sample.default()
+        surfactant = SurfactantLayer.default()
+        p.append(surfactant)
+        multilayer = Multilayer.default()
+        p.append(multilayer)
+        repeating = RepeatingMultilayer.default()
+        p.append(repeating)
+
         q = Sample.from_dict(p.as_dict())
         assert p.as_data_dict() == q.as_data_dict()


### PR DESCRIPTION
General
- added `as_dict` method for classes where the produced dictionary needs to be customized to fit the constructor
- added pipelines to handle draft of release notes 

In `model.py` made it more clear that the underlying `sample` consists of `assemblies` 

In `surfactant_layer.py`
- protected `_area_per_molecule`

In `layer_area_per_molecule.py`
- protected `_area_per_molecule`
- protected `_scattering_length_real`
- protected `_scattering_length_imag`
