### PR TITLE
Resolution smearing function in refl1d

### DIFF
--- a/EasyReflectometry/calculators/bornagain/calculator.py
+++ b/EasyReflectometry/calculators/bornagain/calculator.py
@@ -3,7 +3,7 @@ __author__ = 'github.com/arm61'
 import numpy as np
 from easyCore.Objects.Inferface import ItemContainer
 
-from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.experiment import Model
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import Material
 from EasyReflectometry.sample import MaterialMixture

--- a/EasyReflectometry/calculators/bornagain/wrapper.py
+++ b/EasyReflectometry/calculators/bornagain/wrapper.py
@@ -245,23 +245,23 @@ class BornAgainWrapper(WrapperBase):
         del self.storage['item_repeats'][item_name]
         del self.storage['item'][item_name]
 
-    def calculate(self, x_array: np.ndarray) -> np.ndarray:
-        """
-        For a given x calculate the corresponding y.
+    # To conform the base class the signature should be
+    # def calculate(self, q_array: np.ndarray, model_name: str) -> np.ndarray:
+    def calculate(self, q_array: np.ndarray) -> np.ndarray:
+        """For a given q array calculate the corresponding reflectivity.
 
-        :param x_array: array of data points to be calculated
-        :type x_array: np.ndarray
-        :return: points calculated at `x`
-        :rtype: np.ndarray
+        :param q_array: array of data points to be calculated
+        :param model_name: the model name
+        :return: reflectivity calculated at q
         """
         # 3.5 sigma to sync with refnx
         n_sig = 3.5
         n_samples = 21
         distr = ba.RangedDistributionGaussian(n_samples, n_sig)
 
-        scan = ba.QSpecScan(x_array / ba.angstrom)
+        scan = ba.QSpecScan(q_array / ba.angstrom)
         scan.setAbsoluteQResolution(
-            distr, x_array / ba.angstrom * (self.storage['model_parameters']['resolution'] * 0.5 / 100)
+            distr, q_array / ba.angstrom * (self.storage['model_parameters']['resolution'] * 0.5 / 100)
         )
 
         simulation = ba.SpecularSimulation()

--- a/EasyReflectometry/calculators/calculator_base.py
+++ b/EasyReflectometry/calculators/calculator_base.py
@@ -6,7 +6,7 @@ import numpy as np
 from easyCore.Objects.core import ComponentSerializer
 from easyCore.Objects.Inferface import ItemContainer
 
-from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.experiment import Model
 from EasyReflectometry.sample import BaseAssembly
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import Material

--- a/EasyReflectometry/calculators/refl1d/calculator.py
+++ b/EasyReflectometry/calculators/refl1d/calculator.py
@@ -28,7 +28,6 @@ class Refl1d(CalculatorBase):
     _model_link = {
         'scale': 'scale',
         'background': 'bkg',
-        'resolution': 'dq',
     }
 
     def __init__(self):

--- a/EasyReflectometry/calculators/refl1d/wrapper.py
+++ b/EasyReflectometry/calculators/refl1d/wrapper.py
@@ -8,6 +8,9 @@ from refl1d import names
 
 from ..wrapper_base import WrapperBase
 
+PADDING_RANGE = 3.5
+UPSCALE_FACTOR = 21
+
 
 class Refl1dWrapper(WrapperBase):
     def create_material(self, name: str):
@@ -168,9 +171,9 @@ class Refl1dWrapper(WrapperBase):
             background=self.storage['model'][model_name]['bkg'],
         )
         q.calc_Qo = np.linspace(
-            q_array[argmin] - 3.5 * dq_vector_normalized_to_refnx[argmin],
-            q_array[argmax] + 3.5 * dq_vector_normalized_to_refnx[argmax],
-            21 * len(q_array),
+            q_array[argmin] - PADDING_RANGE * dq_vector_normalized_to_refnx[argmin],
+            q_array[argmax] + PADDING_RANGE * dq_vector_normalized_to_refnx[argmax],
+            UPSCALE_FACTOR * len(q_array),
         )
         R = names.Experiment(probe=q, sample=structure).reflectivity()[1]
         return R

--- a/EasyReflectometry/calculators/refnx/wrapper.py
+++ b/EasyReflectometry/calculators/refnx/wrapper.py
@@ -113,13 +113,12 @@ class RefnxWrapper(WrapperBase):
         del self.storage['model'][model_name].structure.components[item_idx]
         del self.storage['item'][item_name]
 
-    def calculate(self, x_array: np.ndarray, model_name: str) -> np.ndarray:
-        """
-        For a given x calculate the corresponding y.
+    def calculate(self, q_array: np.ndarray, model_name: str) -> np.ndarray:
+        """For a given q array calculate the corresponding reflectivity.
 
-        :param x_array: array of data points to be calculated
-        :param model_name: Name for the model
-        :return: points calculated at `x`
+        :param q_array: array of data points to be calculated
+        :param model_name: the model name
+        :return: reflectivity calculated at q
         """
         structure = _remove_unecessary_stacks(self.storage['model'][model_name].structure)
         model = reflect.ReflectModel(
@@ -128,7 +127,7 @@ class RefnxWrapper(WrapperBase):
             bkg=self.storage['model'][model_name].bkg.value,
             dq=self.storage['model'][model_name].dq.value,
         )
-        return model(x_array)
+        return model(q_array)
 
     def sld_profile(self, model_name: str) -> Tuple[np.ndarray, np.ndarray]:
         """

--- a/EasyReflectometry/calculators/wrapper_base.py
+++ b/EasyReflectometry/calculators/wrapper_base.py
@@ -1,3 +1,4 @@
+import sys
 from abc import abstractmethod
 from typing import Callable
 
@@ -13,8 +14,7 @@ class WrapperBase:
             'item': {},
             'model': {},
         }
-        #        self._resolution_function = constant_resolution_function(5)
-        self._resolution_function = linear_spline_resolution_function([0, 100], [5, 5])
+        self._resolution_function = constant_resolution_function(5)
 
     def reset_storage(self):
         """Reset the storage area to blank."""
@@ -212,10 +212,7 @@ class WrapperBase:
 
 
 def constant_resolution_function(constant: float) -> Callable[[np.array], float]:
-    def resolution_function(q: np.array) -> np.array:
-        return np.ones_like(q) * constant
-
-    return resolution_function
+    return linear_spline_resolution_function([sys.float_info.min, sys.float_info.max], [constant, constant])
 
 
 def linear_spline_resolution_function(q_data_points: np.array, resolution_points: np.array) -> Callable[[np.array], float]:

--- a/EasyReflectometry/calculators/wrapper_base.py
+++ b/EasyReflectometry/calculators/wrapper_base.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Callable
 
 import numpy as np
 
@@ -12,6 +13,8 @@ class WrapperBase:
             'item': {},
             'model': {},
         }
+        #        self._resolution_function = constant_resolution_function(5)
+        self._resolution_function = linear_spline_resolution_function([0, 100], [5, 5])
 
     def reset_storage(self):
         """Reset the storage area to blank."""
@@ -119,11 +122,12 @@ class WrapperBase:
         ...
 
     @abstractmethod
-    def calculate(self, x_array: np.ndarray, model_name: str) -> np.ndarray:
-        """For a given x calculate the corresponding y.
+    def calculate(self, q_array: np.ndarray, model_name: str) -> np.ndarray:
+        """For a given q array calculate the corresponding reflectivity.
 
-        :param x_array: array of data points to be calculated
-        :param model_name: Name for the model
+        :param q_array: array of data points to be calculated
+        :param model_name: the model name
+        :return: reflectivity calculated at q
         """
         ...
 
@@ -198,3 +202,24 @@ class WrapperBase:
         item = self.storage['item'][name]
         item = getattr(item, key)
         return getattr(item, 'value')
+
+    def set_resolution_function(self, resolution_function: Callable[[np.array], float]) -> None:
+        """Set the resolution function for the calculator.
+
+        :param resolution_function: The resolution function
+        """
+        self._resolution_function = resolution_function
+
+
+def constant_resolution_function(constant: float) -> Callable[[np.array], float]:
+    def resolution_function(q: np.array) -> np.array:
+        return np.ones_like(q) * constant
+
+    return resolution_function
+
+
+def linear_spline_resolution_function(q_data_points: np.array, resolution_points: np.array) -> Callable[[np.array], float]:
+    def resolution_function(q: np.array) -> np.array:
+        return np.interp(q, q_data_points, resolution_points)
+
+    return resolution_function

--- a/EasyReflectometry/calculators/wrapper_base.py
+++ b/EasyReflectometry/calculators/wrapper_base.py
@@ -1,8 +1,9 @@
-import sys
 from abc import abstractmethod
 from typing import Callable
 
 import numpy as np
+
+from EasyReflectometry.experiment import constant_resolution_function
 
 
 class WrapperBase:
@@ -209,14 +210,3 @@ class WrapperBase:
         :param resolution_function: The resolution function
         """
         self._resolution_function = resolution_function
-
-
-def constant_resolution_function(constant: float) -> Callable[[np.array], float]:
-    return linear_spline_resolution_function([sys.float_info.min, sys.float_info.max], [constant, constant])
-
-
-def linear_spline_resolution_function(q_data_points: np.array, resolution_points: np.array) -> Callable[[np.array], float]:
-    def resolution_function(q: np.array) -> np.array:
-        return np.interp(q, q_data_points, resolution_points)
-
-    return resolution_function

--- a/EasyReflectometry/experiment/__init__.py
+++ b/EasyReflectometry/experiment/__init__.py
@@ -1,0 +1,11 @@
+from .model import Model
+from .models import Models
+from .resolution_functions import constant_resolution_function
+from .resolution_functions import linear_spline_resolution_function
+
+__all__ = (
+    constant_resolution_function,
+    linear_spline_resolution_function,
+    Model,
+    Models,
+)

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -10,11 +10,12 @@ from easyCore import np
 from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.ObjectClasses import Parameter
 
-from EasyReflectometry.calculators.wrapper_base import constant_resolution_function
 from EasyReflectometry.sample import BaseAssembly
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
 from EasyReflectometry.sample import Sample
+
+from .resolution_functions import constant_resolution_function
 
 MODEL_DETAILS = {
     'scale': {
@@ -191,9 +192,8 @@ class Model(BaseObj):
     @property
     def _dict_repr(self) -> dict[str, dict[str, str]]:
         """A simplified dict representation."""
-        resolution_values = self._resolution_function([0.1, 0.2])
-        if resolution_values[0] == resolution_values[1]:
-            resolution = f'{resolution_values[0]} %'
+        if self._resolution_function.__qualname__.split('.')[0] == 'constant_resolution_function':
+            resolution = f'{self._resolution_function([0])[0]} %'
         else:
             resolution = 'function of Q'
 

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -65,7 +65,7 @@ class Model(BaseObj):
         :param scale: Scaling factor of profile.
         :param background: Linear background magnitude.
         :param name: Name of the model, defaults to 'EasyModel'.
-        :param interface: Calculator interface, defaults to :py:attr:`None`.
+        :param interface: Calculator interface, defaults to `None`.
 
         """
         super().__init__(

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -193,7 +193,8 @@ class Model(BaseObj):
     def _dict_repr(self) -> dict[str, dict[str, str]]:
         """A simplified dict representation."""
         if self._resolution_function.__qualname__.split('.')[0] == 'constant_resolution_function':
-            resolution = f'{self._resolution_function([0])[0]} %'
+            resolution_value = self._resolution_function([0])[0]
+            resolution = f'{resolution_value} %'
         else:
             resolution = 'function of Q'
 

--- a/EasyReflectometry/experiment/models.py
+++ b/EasyReflectometry/experiment/models.py
@@ -5,16 +5,11 @@ from typing import List
 import yaml
 from easyCore.Objects.Groups import BaseCollection
 
-from EasyReflectometry.experiment.model import Model
+from .model import Model
 
 
 class Models(BaseCollection):
-
-    def __init__(self,
-                 *args: List[Model],
-                 name: str = 'EasyModels',
-                 interface=None,
-                 **kwargs):
+    def __init__(self, *args: List[Model], name: str = 'EasyModels', interface=None, **kwargs):
         super().__init__(name, *args, **kwargs)
         self.interface = interface
 
@@ -31,10 +26,7 @@ class Models(BaseCollection):
         return cls(model1, model2, interface=interface)
 
     @classmethod
-    def from_pars(cls,
-                  *args: List[Model],
-                  name: str = 'EasyModels',
-                  interface=None) -> 'Models':
+    def from_pars(cls, *args: List[Model], name: str = 'EasyModels', interface=None) -> 'Models':
         """
         Constructor for the models where models are being given.
 

--- a/EasyReflectometry/experiment/resolution_functions.py
+++ b/EasyReflectometry/experiment/resolution_functions.py
@@ -1,0 +1,36 @@
+from typing import Callable
+
+import numpy as np
+
+
+def constant_resolution_function(constant: float) -> Callable[[np.array], np.array]:
+    """Create a resolution function that is constant across the q range.
+
+    :param constant: The constant resolution value.
+    """
+
+    def _constant(q: np.array) -> np.array:
+        """Function that calculates the resolution at a given q value.
+
+        The function uses the data points from the encapsulating function and produces a linearly interpolated between them.
+        """
+        return np.ones(len(q)) * constant
+
+    return _constant
+
+
+def linear_spline_resolution_function(q_data_points: np.array, resolution_points: np.array) -> Callable[[np.array], np.array]:
+    """Create a resolution function that is linearly interpolated between given data points.
+
+    :param q_data_points: The q values at which the resolution is defined.
+    :param resolution_points: The resolution values at the given q values.
+    """
+
+    def _linear(q: np.array) -> np.array:
+        """Function that calculates the resolution at a given q value.
+
+        The function uses the data points from the encapsulating function and produces a linearly interpolated between them.
+        """
+        return np.interp(q, q_data_points, resolution_points)
+
+    return _linear

--- a/EasyReflectometry/fitting.py
+++ b/EasyReflectometry/fitting.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipp as sc
 from easyCore.Fitting.Fitting import MultiFitter as easyFitter
 
-from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.experiment import Model
 
 
 class Fitter:

--- a/tests/calculators/refl1d/test_refl1d_calculator.py
+++ b/tests/calculators/refl1d/test_refl1d_calculator.py
@@ -1,6 +1,7 @@
 """
 Tests for Refnx calculator.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -24,7 +25,7 @@ class TestRefl1d(unittest.TestCase):
         assert_equal(p._item_link['repetitions'], 'repeat')
         assert_equal(p._model_link['scale'], 'scale')
         assert_equal(p._model_link['background'], 'bkg')
-        assert_equal(p._model_link['resolution'], 'dq')
+        #        assert_equal(p._model_link['resolution'], 'dq')
         assert_equal(p.name, 'refl1d')
 
     def test_fit_func(self):
@@ -36,7 +37,8 @@ class TestRefl1d(unittest.TestCase):
         p._wrapper.create_material('Material3')
         p._wrapper.update_material('Material3', rho=4.000, irho=0.000)
         p._wrapper.create_model('MyModel')
-        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
+        p._wrapper.update_model('MyModel', bkg=1e-7)
+        #        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
         p._wrapper.create_layer('Layer1')
         p._wrapper.assign_material_to_layer('Material1', 'Layer1')
         p._wrapper.create_layer('Layer2')
@@ -74,7 +76,8 @@ class TestRefl1d(unittest.TestCase):
         p._wrapper.create_material('Material3')
         p._wrapper.update_material('Material3', rho=4.000, irho=0.000)
         p._wrapper.create_model('MyModel')
-        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
+        #        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
+        p._wrapper.update_model('MyModel', bkg=1e-7)
         p._wrapper.create_layer('Layer1')
         p._wrapper.assign_material_to_layer('Material1', 'Layer1')
         p._wrapper.create_layer('Layer2')

--- a/tests/calculators/refl1d/test_refl1d_calculator.py
+++ b/tests/calculators/refl1d/test_refl1d_calculator.py
@@ -25,7 +25,6 @@ class TestRefl1d(unittest.TestCase):
         assert_equal(p._item_link['repetitions'], 'repeat')
         assert_equal(p._model_link['scale'], 'scale')
         assert_equal(p._model_link['background'], 'bkg')
-        #        assert_equal(p._model_link['resolution'], 'dq')
         assert_equal(p.name, 'refl1d')
 
     def test_fit_func(self):
@@ -38,7 +37,6 @@ class TestRefl1d(unittest.TestCase):
         p._wrapper.update_material('Material3', rho=4.000, irho=0.000)
         p._wrapper.create_model('MyModel')
         p._wrapper.update_model('MyModel', bkg=1e-7)
-        #        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
         p._wrapper.create_layer('Layer1')
         p._wrapper.assign_material_to_layer('Material1', 'Layer1')
         p._wrapper.create_layer('Layer2')
@@ -76,7 +74,6 @@ class TestRefl1d(unittest.TestCase):
         p._wrapper.create_material('Material3')
         p._wrapper.update_material('Material3', rho=4.000, irho=0.000)
         p._wrapper.create_model('MyModel')
-        #        p._wrapper.update_model('MyModel', bkg=1e-7, dq=5.0)
         p._wrapper.update_model('MyModel', bkg=1e-7)
         p._wrapper.create_layer('Layer1')
         p._wrapper.assign_material_to_layer('Material1', 'Layer1')

--- a/tests/calculators/refl1d/test_refl1d_wrapper.py
+++ b/tests/calculators/refl1d/test_refl1d_wrapper.py
@@ -1,6 +1,7 @@
 """
 Tests for Refl1d wrapper.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -94,23 +95,27 @@ class TestRefl1d(unittest.TestCase):
     def test_create_model(self):
         p = Refl1dWrapper()
         p.create_model('MyModel')
-        assert_equal(p.storage['model']['MyModel'], {'scale': 1, 'bkg': 0, 'dq': 0, 'items': []})
+        assert_equal(p.storage['model']['MyModel'], {'scale': 1, 'bkg': 0, 'items': []})
 
     def test_update_model(self):
         p = Refl1dWrapper()
         p.create_model('MyModel')
-        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
+        p.update_model('MyModel', scale=2, bkg=1e-3)
+        #        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
         assert_almost_equal(p.storage['model']['MyModel']['scale'], 2)
         assert_almost_equal(p.storage['model']['MyModel']['bkg'], 1e-3)
-        assert_almost_equal(p.storage['model']['MyModel']['dq'], 2.0)
+
+    #        assert_almost_equal(p.storage['model']['MyModel']['dq'], 2.0)
 
     def test_get_model_value(self):
         p = Refl1dWrapper()
         p.create_model('MyModel')
-        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
+        #        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
+        p.update_model('MyModel', scale=2, bkg=1e-3)
         assert_almost_equal(p.get_model_value('MyModel', 'scale'), 2)
         assert_almost_equal(p.get_model_value('MyModel', 'bkg'), 1e-3)
-        assert_almost_equal(p.get_model_value('MyModel', 'dq'), 2.0)
+
+    #        assert_almost_equal(p.get_model_value('MyModel', 'dq'), 2.0)
 
     def test_assign_material_to_layer(self):
         p = Refl1dWrapper()
@@ -182,7 +187,9 @@ class TestRefl1d(unittest.TestCase):
         p.create_material('Material3')
         p.update_material('Material3', rho=4.000, irho=0.000)
         p.create_model('MyModel')
+        p.update_model('MyModel', bkg=1e-7)
         p.update_model('MyModel', bkg=1e-7, dq=5.0)
+        #        p.update_model('MyModel', bkg=1e-7, dq=5.0)
         p.create_layer('Layer1')
         p.assign_material_to_layer('Material1', 'Layer1')
         p.create_layer('Layer2')
@@ -220,7 +227,8 @@ class TestRefl1d(unittest.TestCase):
         p.create_material('Material3')
         p.update_material('Material3', rho=4.000, irho=0.000)
         p.create_model('MyModel')
-        p.update_model('MyModel', bkg=1e-7, dq=5.0)
+        p.update_model('MyModel', bkg=1e-7)
+        #        p.update_model('MyModel', bkg=1e-7, dq=5.0)
         p.create_layer('Layer1')
         p.assign_material_to_layer('Material1', 'Layer1')
         p.create_layer('Layer2')

--- a/tests/calculators/refl1d/test_refl1d_wrapper.py
+++ b/tests/calculators/refl1d/test_refl1d_wrapper.py
@@ -57,8 +57,6 @@ class TestRefl1d(unittest.TestCase):
         assert_equal(list(p.storage['layer'].keys()), ['Si'])
         assert_almost_equal(p.storage['layer']['Si'].thickness.value, 0)
         assert_almost_equal(p.storage['layer']['Si'].interface.value, 0)
-        # assert_almost_equal(p.storage['layer']['Si'].material.rho.value, 0)
-        # assert_almost_equal(p.storage['layer']['Si'].material.irho.value, 0)
 
     def test_update_layer(self):
         p = Refl1dWrapper()
@@ -101,21 +99,15 @@ class TestRefl1d(unittest.TestCase):
         p = Refl1dWrapper()
         p.create_model('MyModel')
         p.update_model('MyModel', scale=2, bkg=1e-3)
-        #        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
         assert_almost_equal(p.storage['model']['MyModel']['scale'], 2)
         assert_almost_equal(p.storage['model']['MyModel']['bkg'], 1e-3)
-
-    #        assert_almost_equal(p.storage['model']['MyModel']['dq'], 2.0)
 
     def test_get_model_value(self):
         p = Refl1dWrapper()
         p.create_model('MyModel')
-        #        p.update_model('MyModel', scale=2, bkg=1e-3, dq=2.0)
         p.update_model('MyModel', scale=2, bkg=1e-3)
         assert_almost_equal(p.get_model_value('MyModel', 'scale'), 2)
         assert_almost_equal(p.get_model_value('MyModel', 'bkg'), 1e-3)
-
-    #        assert_almost_equal(p.get_model_value('MyModel', 'dq'), 2.0)
 
     def test_assign_material_to_layer(self):
         p = Refl1dWrapper()
@@ -189,7 +181,6 @@ class TestRefl1d(unittest.TestCase):
         p.create_model('MyModel')
         p.update_model('MyModel', bkg=1e-7)
         p.update_model('MyModel', bkg=1e-7, dq=5.0)
-        #        p.update_model('MyModel', bkg=1e-7, dq=5.0)
         p.create_layer('Layer1')
         p.assign_material_to_layer('Material1', 'Layer1')
         p.create_layer('Layer2')
@@ -228,7 +219,6 @@ class TestRefl1d(unittest.TestCase):
         p.update_material('Material3', rho=4.000, irho=0.000)
         p.create_model('MyModel')
         p.update_model('MyModel', bkg=1e-7)
-        #        p.update_model('MyModel', bkg=1e-7, dq=5.0)
         p.create_layer('Layer1')
         p.assign_material_to_layer('Material1', 'Layer1')
         p.create_layer('Layer2')

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -7,12 +7,15 @@ __version__ = '0.0.1'
 
 
 import unittest
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
 from EasyReflectometry.calculators import CalculatorFactory
+from EasyReflectometry.calculators.wrapper_base import constant_resolution_function
+from EasyReflectometry.calculators.wrapper_base import linear_spline_resolution_function
 from EasyReflectometry.experiment.model import Model
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
@@ -41,12 +44,8 @@ class TestModel(unittest.TestCase):
         assert_equal(p.background.min, 0.0)
         assert_equal(p.background.max, np.Inf)
         assert_equal(p.background.fixed, True)
-        assert_equal(p.resolution.display_name, 'resolution')
-        assert_equal(str(p.resolution.unit), 'dimensionless')
-        assert_equal(p.resolution.value.value.magnitude, 5.0)
-        assert_equal(p.resolution.min, 0.0)
-        assert_equal(p.resolution.max, 100.0)
-        assert_equal(p.resolution.fixed, True)
+        assert p._resolution_function(1) == 5.0
+        assert p._resolution_function(100) == 5.0
 
     def test_from_pars(self):
         m1 = Material.from_pars(6.908, -0.278, 'Boron')
@@ -58,7 +57,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, o2, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel')
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(mod.name, 'newModel')
         assert_equal(mod.interface, None)
         assert_equal(mod.sample.name, 'myModel')
@@ -74,12 +74,8 @@ class TestModel(unittest.TestCase):
         assert_equal(mod.background.min, 0.0)
         assert_equal(mod.background.max, np.Inf)
         assert_equal(mod.background.fixed, True)
-        assert_equal(mod.resolution.display_name, 'resolution')
-        assert_equal(str(mod.resolution.unit), 'dimensionless')
-        assert_equal(mod.resolution.value.value.magnitude, 2.0)
-        assert_equal(mod.resolution.min, 0.0)
-        assert_equal(mod.resolution.max, 100.0)
-        assert_equal(mod.resolution.fixed, True)
+        assert mod._resolution_function(1) == 2.0
+        assert mod._resolution_function(100) == 2.0
 
     def test_add_item(self):
         m1 = Material.from_pars(6.908, -0.278, 'Boron')
@@ -93,7 +89,8 @@ class TestModel(unittest.TestCase):
         surfactant = SurfactantLayer.default()
         multilayer = Multilayer.default()
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel')
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -123,7 +120,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -142,7 +140,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -178,7 +177,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel')
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -198,7 +198,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         mod.add_item(o2)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 2)
@@ -217,7 +218,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         mod.add_item(o2)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 2)
@@ -253,7 +255,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel')
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -271,7 +274,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -293,7 +297,8 @@ class TestModel(unittest.TestCase):
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
-        mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+        resolution_function = constant_resolution_function(2.0)
+        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -329,22 +334,41 @@ class TestModel(unittest.TestCase):
         p = Model.default()
         assert_equal(p.uid, p._borg.map.convert_id_to_key(p))
 
+    def test_set_resolution_function(self):
+        mock_resolution_function = MagicMock()
+        model = Model.default()
+        model.set_resolution_function(mock_resolution_function)
+        assert model._resolution_function == mock_resolution_function
+
     def test_repr(self):
-        p = Model.default()
+        model = Model.default()
+
         assert (
-            p.__repr__()
+            model.__repr__()
             == 'EasyModel:\n  scale: 1.0\n  background: 1.0e-08\n  resolution: 5.0 %\n  sample:\n    EasySample:\n    - EasyMultilayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n    - EasyMultilayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n'  # noqa: E501
         )
 
+    def test_repr_resolution_function(self):
+        resolution_function = linear_spline_resolution_function([0, 10], [0, 10])
+        model = Model.default()
+        model.set_resolution_function(resolution_function)
+        assert (
+            model.__repr__()
+            == 'EasyModel:\n  scale: 1.0\n  background: 1.0e-08\n  resolution: function of Q\n  sample:\n    EasySample:\n    - EasyMultilayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n    - EasyMultilayer:\n        EasyLayers:\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n        - EasyLayer:\n            material:\n              EasyMaterial:\n                sld: 4.186e-6 1 / angstrom ** 2\n                isld: 0.000e-6 1 / angstrom ** 2\n            thickness: 10.000 angstrom\n            roughness: 3.300 angstrom\n'  # noqa: E501
+        )
+
     def test_dict_round_trip(self):
+        resolution_function = linear_spline_resolution_function([0, 10], [0, 10])
         interface = CalculatorFactory()
-        p = Model.default(interface)
+        model = Model.default(interface)
+        model.set_resolution_function(resolution_function)
         surfactant = SurfactantLayer.default()
-        p.add_item(surfactant)
+        model.add_item(surfactant)
         multilayer = Multilayer.default()
-        p.add_item(multilayer)
+        model.add_item(multilayer)
         repeating = RepeatingMultilayer.default()
-        p.add_item(repeating)
-        src_dict = p.as_dict()
-        q = Model.from_dict(src_dict)
-        assert p.as_data_dict() == q.as_data_dict()
+        model.add_item(repeating)
+        src_dict = model.as_dict()
+        model_from_dict = Model.from_dict(src_dict)
+        assert model.as_data_dict() == model_from_dict.as_data_dict()
+        assert model._resolution_function(5.5) == model_from_dict._resolution_function(5.5)

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -14,9 +14,9 @@ import pytest
 from numpy.testing import assert_equal
 
 from EasyReflectometry.calculators import CalculatorFactory
-from EasyReflectometry.calculators.wrapper_base import constant_resolution_function
-from EasyReflectometry.calculators.wrapper_base import linear_spline_resolution_function
-from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.experiment import Model
+from EasyReflectometry.experiment import constant_resolution_function
+from EasyReflectometry.experiment import linear_spline_resolution_function
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
 from EasyReflectometry.sample import Material
@@ -44,8 +44,8 @@ class TestModel(unittest.TestCase):
         assert_equal(p.background.min, 0.0)
         assert_equal(p.background.max, np.Inf)
         assert_equal(p.background.fixed, True)
-        assert p._resolution_function(1) == 5.0
-        assert p._resolution_function(100) == 5.0
+        assert p._resolution_function([1]) == 5.0
+        assert p._resolution_function([100]) == 5.0
 
     def test_from_pars(self):
         m1 = Material.from_pars(6.908, -0.278, 'Boron')
@@ -74,8 +74,8 @@ class TestModel(unittest.TestCase):
         assert_equal(mod.background.min, 0.0)
         assert_equal(mod.background.max, np.Inf)
         assert_equal(mod.background.fixed, True)
-        assert mod._resolution_function(1) == 2.0
-        assert mod._resolution_function(100) == 2.0
+        assert mod._resolution_function([1]) == 2.0
+        assert mod._resolution_function([100]) == 2.0
 
     def test_add_item(self):
         m1 = Material.from_pars(6.908, -0.278, 'Boron')

--- a/tests/experiment/test_resolution_functions.py
+++ b/tests/experiment/test_resolution_functions.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from EasyReflectometry.experiment.resolution_functions import constant_resolution_function
+from EasyReflectometry.experiment.resolution_functions import linear_spline_resolution_function
+
+
+def test_constant_resolution_function():
+    resolution_function = constant_resolution_function(5)
+    assert np.all(resolution_function([0, 2.5]) == [5, 5])
+    assert resolution_function([-100]) == 5
+    assert resolution_function([100]) == 5
+
+
+def test_linear_spline_resolution_function():
+    resolution_function = linear_spline_resolution_function([0, 10], [5, 10])
+    assert np.all(resolution_function([0, 2.5]) == [5, 6.25])
+    assert resolution_function([-100]) == 5
+    assert resolution_function([100]) == 10

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -6,7 +6,7 @@ import unittest
 import EasyReflectometry
 from EasyReflectometry.calculators import CalculatorFactory
 from EasyReflectometry.data import load
-from EasyReflectometry.experiment.model import Model
+from EasyReflectometry.experiment import Model
 from EasyReflectometry.fitting import Fitter
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import Material


### PR DESCRIPTION
Introduced resolution function (`resolution_function` ) for refl1d  rather than constant (`dQ`).  The code now supports either a constant value or a linear interpolation between known resolution values (should be read from file in a coming PR).

Coming PRs:
- be able pass resolution data loaded from file #130
- adjust refnx to resolution function #128 