### PR TITLE
132 add direct initialization as replacement for from pars

### DIFF
--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -58,7 +58,7 @@ class Model(BaseObj):
         sample: Union[Sample, None] = None,
         scale: Union[Parameter, Number, None] = None,
         background: Union[Parameter, Number, None] = None,
-        resolution_function: Callable[[np.array], float],
+        resolution_function: Union[Callable[[np.array], float], None] = None,
         name: str = 'EasyModel',
         interface=None,
     ):
@@ -77,10 +77,9 @@ class Model(BaseObj):
         if resolution_function is None:
             resolution_function = constant_resolution_function(MODEL_DETAILS['resolution']['value'])
 
-
         scale = get_as_parameter(scale, 'scale', MODEL_DETAILS)
         background = get_as_parameter(background, 'background', MODEL_DETAILS)
-#        resolution = get_as_parameter(resolution, 'resolution', LAYER_DETAILS)
+        #        resolution = get_as_parameter(resolution, 'resolution', LAYER_DETAILS)
 
         # #        default_options = deepcopy(LAYER_DETAILS)
 

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 __author__ = 'github.com/arm61'
 
-from copy import deepcopy
 from numbers import Number
 from typing import Callable
 from typing import Union
@@ -12,6 +11,7 @@ from easyCore import np
 from easyCore.Objects.ObjectClasses import BaseObj
 from easyCore.Objects.ObjectClasses import Parameter
 
+from EasyReflectometry.parameter_utils import get_as_parameter
 from EasyReflectometry.sample import BaseAssembly
 from EasyReflectometry.sample import Layer
 from EasyReflectometry.sample import LayerCollection
@@ -179,16 +179,3 @@ class Model(BaseObj):
         this_dict = super().as_dict(skip=skip)
         this_dict['sample'] = self.sample.as_dict()
         return this_dict
-
-
-def get_as_parameter(value: Union[Parameter, Number, None], name, default_dict: dict[str, str]) -> Parameter:
-    # Should leave the passed dictionary unchanged
-    default_dict = deepcopy(default_dict)
-    if value is None:
-        return Parameter(name, **default_dict[name])
-    elif isinstance(value, Number):
-        del default_dict[name]['value']
-        return Parameter(name, value, **default_dict[name])
-    elif not isinstance(value, Parameter):
-        raise ValueError(f'{name} must be a Parameter, a number, or None.')
-    return value

--- a/EasyReflectometry/experiment/model.py
+++ b/EasyReflectometry/experiment/model.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 __author__ = 'github.com/arm61'
 
 from copy import deepcopy
-from typing import Callable
 from numbers import Number
+from typing import Callable
 from typing import Union
 
 import yaml
@@ -79,33 +79,6 @@ class Model(BaseObj):
 
         scale = get_as_parameter(scale, 'scale', MODEL_DETAILS)
         background = get_as_parameter(background, 'background', MODEL_DETAILS)
-        #        resolution = get_as_parameter(resolution, 'resolution', LAYER_DETAILS)
-
-        # #        default_options = deepcopy(LAYER_DETAILS)
-
-        #         if scale is None:
-        #             scale = Parameter('scale', **default_options['scale'])
-        #         elif isinstance(scale, Number):
-        #             del default_options['scale']['value']
-        #             scale = Parameter('scale', scale, **default_options['scale'])
-        #         elif not isinstance(scale, Parameter):
-        #             raise ValueError('scale must be a Parameter or a number.')
-
-        #         if background is None:
-        #             background = Parameter('background', **default_options['background'])
-        #         elif isinstance(background, Number):
-        #             del default_options['background']['value']
-        #             background = Parameter('background', background, **default_options['background'])
-        #         elif not isinstance(background, Parameter):
-        #             raise ValueError('background must be a Parameter or a number.')
-
-        #         if resolution is None:
-        #             resolution = Parameter('resolution', **default_options['resolution'])
-        #         elif isinstance(resolution, Number):
-        #             del default_options['resolution']['value']
-        #             resolution = Parameter('resolution', resolution, **default_options['resolution'])
-        #         elif not isinstance(resolution, Parameter):
-        #             raise ValueError('resolution must be a Parameter or a number.')
 
         super().__init__(
             name=name,
@@ -115,56 +88,6 @@ class Model(BaseObj):
         )
         self.interface = interface
         self._resolution_function = resolution_function
-
-    # # Class methods for instance creation
-    # @classmethod
-    # def default(cls, interface=None) -> Model:
-    #     """Default instance of the reflectometry experiment model.
-
-    #     :param interface: Calculator interface, defaults to :py:attr:`None`.
-    #     """
-    #     sample = Sample.default()
-    #     scale = Parameter('scale', **LAYER_DETAILS['scale'])
-    #     background = Parameter('background', **LAYER_DETAILS['background'])
-    #     resolution = Parameter('resolution', **LAYER_DETAILS['resolution'])
-    #     return cls(sample, scale, background, resolution, interface=interface)
-
-    # @classmethod
-    # def from_pars(
-    #     cls,
-    #     sample: Sample,
-    #     scale: Parameter,
-    #     background: Parameter,
-    #     resolution: Parameter,
-    #     name: str = 'EasyModel',
-    #     interface=None,
-    # ) -> Model:
-    #     """Instance of a reflectometry experiment model where the parameters are known.
-
-    #     :param sample: The sample being modelled.
-    #     :param scale: Scaling factor of profile.
-    #     :param background: Linear background magnitude.
-    #     :param resolution: Constant resolution smearing percentage.
-    #     :param name: Name of the layer, defaults to 'EasyModel'.
-    #     :param interface: Calculator interface, defaults to :py:attr:`None`.
-    #     """
-    #     default_options = deepcopy(LAYER_DETAILS)
-    #     del default_options['scale']['value']
-    #     del default_options['background']['value']
-    #     del default_options['resolution']['value']
-
-    #     scale = Parameter('scale', scale, **default_options['scale'])
-    #     background = Parameter('background', background, **default_options['background'])
-    #     resolution = Parameter('resolution', resolution, **default_options['resolution'])
-
-    #     return cls(
-    #         sample=sample,
-    #         scale=scale,
-    #         background=background,
-    #         resolution=resolution,
-    #         name=name,
-    #         interface=interface,
-    #     )
 
     def add_item(self, *assemblies: list[BaseAssembly]) -> None:
         """Add a layer or item to the model sample.

--- a/EasyReflectometry/parameter_utils.py
+++ b/EasyReflectometry/parameter_utils.py
@@ -1,0 +1,18 @@
+from copy import deepcopy
+from numbers import Number
+from typing import Union
+
+from easyCore.Objects.ObjectClasses import Parameter
+
+
+def get_as_parameter(value: Union[Parameter, Number, None], name, default_dict: dict[str, str]) -> Parameter:
+    # Should leave the passed dictionary unchanged
+    default_dict = deepcopy(default_dict)
+    if value is None:
+        return Parameter(name, **default_dict[name])
+    elif isinstance(value, Number):
+        del default_dict[name]['value']
+        return Parameter(name, value, **default_dict[name])
+    elif not isinstance(value, Parameter):
+        raise ValueError(f'{name} must be a Parameter, a number, or None.')
+    return value

--- a/EasyReflectometry/parameter_utils.py
+++ b/EasyReflectometry/parameter_utils.py
@@ -5,12 +5,24 @@ from typing import Union
 from easyCore.Objects.ObjectClasses import Parameter
 
 
-def get_as_parameter(value: Union[Parameter, Number, None], name, default_dict: dict[str, str]) -> Parameter:
+def get_as_parameter(value: Union[Parameter, Number, None], name: str, default_dict: dict[str, str]) -> Parameter:
+    """
+    This function creates a parameter for the variable `name`.  A parameter has a value and metadata.
+    If the value already is a parameter, it is returned.
+    If the value is a number, a parameter is created with this value and metadata from the dictionary.
+    If the value is None, a parameter is created with the default value and metadata from the dictionary.
+
+    param value: The value to use for the parameter.  If None, the default value in the dictionary is used.
+    param name: The name of the parameter
+    param default_dict: Dictionary with entry for `name` containing the default value and metadata for the parameter
+    """
     # Should leave the passed dictionary unchanged
     local_dict = deepcopy(default_dict)
     if value is None:
+        # Create a default parameter using both value and metadata from dictionary
         return Parameter(name, **local_dict[name])
     elif isinstance(value, Number):
+        # Create a parameter using provided value and metadata from dictionary
         del local_dict[name]['value']
         return Parameter(name, value, **local_dict[name])
     elif not isinstance(value, Parameter):

--- a/EasyReflectometry/parameter_utils.py
+++ b/EasyReflectometry/parameter_utils.py
@@ -7,12 +7,12 @@ from easyCore.Objects.ObjectClasses import Parameter
 
 def get_as_parameter(value: Union[Parameter, Number, None], name, default_dict: dict[str, str]) -> Parameter:
     # Should leave the passed dictionary unchanged
-    default_dict = deepcopy(default_dict)
+    local_dict = deepcopy(default_dict)
     if value is None:
-        return Parameter(name, **default_dict[name])
+        return Parameter(name, **local_dict[name])
     elif isinstance(value, Number):
-        del default_dict[name]['value']
-        return Parameter(name, value, **default_dict[name])
+        del local_dict[name]['value']
+        return Parameter(name, value, **local_dict[name])
     elif not isinstance(value, Parameter):
         raise ValueError(f'{name} must be a Parameter, a number, or None.')
     return value

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -58,7 +58,13 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, o2, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model(d, 2, 1e-5, resolution_function, 'newModel')
+        mod = Model(
+            sample=d,
+            scale=2,
+            background=1e-5,
+            resolution_function=resolution_function,
+            name='newModel',
+        )
         assert_equal(mod.name, 'newModel')
         assert_equal(mod.interface, None)
         assert_equal(mod.sample.name, 'myModel')

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -28,7 +28,7 @@ from EasyReflectometry.sample import SurfactantLayer
 
 class TestModel(unittest.TestCase):
     def test_default(self):
-        p = Model.default()
+        p = Model()
         assert_equal(p.name, 'EasyModel')
         assert_equal(p.interface, None)
         assert_equal(p.sample.name, 'EasySample')
@@ -58,7 +58,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, o2, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(mod.name, 'newModel')
         assert_equal(mod.interface, None)
         assert_equal(mod.sample.name, 'myModel')
@@ -90,7 +90,7 @@ class TestModel(unittest.TestCase):
         multilayer = Multilayer.default()
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -103,7 +103,7 @@ class TestModel(unittest.TestCase):
 
     def test_add_item_exception(self):
         # When
-        mod = Model.default()
+        mod = Model()
 
         # Then Expect
         with pytest.raises(ValueError):
@@ -121,7 +121,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -141,7 +141,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -160,7 +160,7 @@ class TestModel(unittest.TestCase):
     #     o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
     #     o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
     #     d = Sample.from_pars(o1, name='myModel')
-    #     mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+    #     mod = Model(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
     #     assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
     #     assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
     #     mod.add_item(o2)
@@ -178,7 +178,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -199,7 +199,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         mod.add_item(o2)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 2)
@@ -219,7 +219,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         mod.add_item(o2)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 2)
@@ -238,7 +238,7 @@ class TestModel(unittest.TestCase):
     #     o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
     #     o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
     #     d = Sample.from_pars(o1, name='myModel')
-    #     mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+    #     mod = Model(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
     #     assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
     #     mod.add_item(o2)
     #     assert_equal(len(mod.interface()._wrapper.storage['item']), 2)
@@ -256,7 +256,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel')
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel')
         assert_equal(len(mod.sample), 1)
         mod.add_item(o2)
         assert_equal(len(mod.sample), 2)
@@ -275,7 +275,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample.from_pars(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -296,7 +296,7 @@ class TestModel(unittest.TestCase):
         ls2 = LayerCollection.from_pars(l2, l1, name='twoLayer2')
         o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
-        d = Sample.from_pars(o1, name='myModel')
+        d = Sample(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
         mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
@@ -320,7 +320,7 @@ class TestModel(unittest.TestCase):
     #     o1 = RepeatingMultilayer.from_pars(ls1, 2.0, 'twoLayerItem1')
     #     o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
     #     d = Sample.from_pars(o1, name='myModel')
-    #     mod = Model.from_pars(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
+    #     mod = Model(d, 2, 1e-5, 2.0, 'newModel', interface=interface)
     #     assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
     #     assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
     #     mod.add_item(o2)
@@ -331,7 +331,7 @@ class TestModel(unittest.TestCase):
     #     assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
 
     def test_uid(self):
-        p = Model.default()
+        p = Model()
         assert_equal(p.uid, p._borg.map.convert_id_to_key(p))
 
     def test_set_resolution_function(self):
@@ -341,7 +341,7 @@ class TestModel(unittest.TestCase):
         assert model._resolution_function == mock_resolution_function
 
     def test_repr(self):
-        model = Model.default()
+        model = Model()
 
         assert (
             model.__repr__()
@@ -350,7 +350,7 @@ class TestModel(unittest.TestCase):
 
     def test_repr_resolution_function(self):
         resolution_function = linear_spline_resolution_function([0, 10], [0, 10])
-        model = Model.default()
+        model = Model()
         model.set_resolution_function(resolution_function)
         assert (
             model.__repr__()
@@ -360,7 +360,7 @@ class TestModel(unittest.TestCase):
     def test_dict_round_trip(self):
         resolution_function = linear_spline_resolution_function([0, 10], [0, 10])
         interface = CalculatorFactory()
-        model = Model.default(interface)
+        model = Model(interface)
         model.set_resolution_function(resolution_function)
         surfactant = SurfactantLayer.default()
         model.add_item(surfactant)

--- a/tests/experiment/test_model.py
+++ b/tests/experiment/test_model.py
@@ -298,7 +298,7 @@ class TestModel(unittest.TestCase):
         o2 = RepeatingMultilayer.from_pars(ls2, 1.0, 'oneLayerItem2')
         d = Sample(o1, name='myModel')
         resolution_function = constant_resolution_function(2.0)
-        mod = Model.from_pars(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
+        mod = Model(d, 2, 1e-5, resolution_function, 'newModel', interface=interface)
         assert_equal(len(mod.interface()._wrapper.storage['item']), 1)
         assert_equal(len(mod.interface()._wrapper.storage['layer']), 2)
         mod.add_item(o2)
@@ -336,7 +336,7 @@ class TestModel(unittest.TestCase):
 
     def test_set_resolution_function(self):
         mock_resolution_function = MagicMock()
-        model = Model.default()
+        model = Model()
         model.set_resolution_function(mock_resolution_function)
         assert model._resolution_function == mock_resolution_function
 
@@ -360,7 +360,7 @@ class TestModel(unittest.TestCase):
     def test_dict_round_trip(self):
         resolution_function = linear_spline_resolution_function([0, 10], [0, 10])
         interface = CalculatorFactory()
-        model = Model(interface)
+        model = Model(interface=interface)
         model.set_resolution_function(resolution_function)
         surfactant = SurfactantLayer.default()
         model.add_item(surfactant)

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -35,7 +35,7 @@ class TestFitting(unittest.TestCase):
             superphase,
             name='Film Structure',
         )
-        model = Model.from_pars(sample, 1, 1e-6, 0.02, 'Film Model')
+        model = Model(sample, 1, 1e-6, 0.02, 'Film Model')
         # Thicknesses
         sio2_layer.thickness.bounds = (15, 50)
         film_layer.thickness.bounds = (200, 300)

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from EasyReflectometry.parameter_utils import get_as_parameter
+
+PARAMETER_DETAILS = {
+    'test_parameter': {
+        'description': 'Test parameter',
+        'url': 'https://veryrealwebsite.com',
+        'value': 1.0,
+        'min': 0,
+        'max': np.Inf,
+        'fixed': True,
+    },
+    'test_parameter_10': {
+        'description': 'Test parameter 10',
+        'url': 'https://veryrealwebsite_10.com',
+        'value': 10.0,
+        'min': -10,
+        'max': 10,
+        'fixed': False,
+    },
+}
+
+
+def test_get_as_parameter():
+    # When
+    test_parameter = None
+
+    # Then
+    test_parameter = get_as_parameter(test_parameter, 'test_parameter', PARAMETER_DETAILS)
+
+    # Expected
+    test_parameter.name == 'test_parameter'
+    assert_equal(str(test_parameter.unit), 'dimensionless')
+    assert_equal(test_parameter.raw_value, 1.0)
+    assert_equal(test_parameter.min, 0.0)
+    assert_equal(test_parameter.max, np.Inf)
+    assert_equal(test_parameter.fixed, True)
+    assert_equal(test_parameter.description, 'Test parameter')
+
+
+def test_get_as_parameter_from_float():
+    # When
+    test_parameter = 2.0
+
+    # Then
+    test_parameter = get_as_parameter(float(test_parameter), 'test_parameter', PARAMETER_DETAILS)
+
+    # Expected
+    assert_equal(test_parameter.raw_value, 2.0)
+
+
+def test_get_as_parameter_from_int():
+    # When
+    test_parameter = 2.0
+
+    # Then
+    test_parameter = get_as_parameter(int(test_parameter), 'test_parameter', PARAMETER_DETAILS)
+
+    # Expected
+    assert_equal(test_parameter.raw_value, 2.0)
+
+
+def test_get_as_parameter_from_parameter():
+    # When
+    test_parameter_10 = get_as_parameter(None, 'test_parameter_10', PARAMETER_DETAILS)
+
+    # Then
+    test_parameter = get_as_parameter(test_parameter_10, 'test_parameter', PARAMETER_DETAILS)
+
+    # Expected
+    test_parameter.name == 'test_parameter'
+    assert_equal(str(test_parameter.unit), 'dimensionless')
+    assert_equal(test_parameter.raw_value, 10.0)
+    assert_equal(test_parameter.min, -10.0)
+    assert_equal(test_parameter.max, 10.0)
+    assert_equal(test_parameter.fixed, False)
+    assert_equal(test_parameter.description, 'Test parameter 10')
+
+
+def test_get_as_parameter_not_number():
+    # When
+    test_parameter = '2.0'
+
+    # Then Expected
+    with pytest.raises(ValueError):
+        test_parameter = get_as_parameter(test_parameter, 'test_parameter', PARAMETER_DETAILS)

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -87,3 +87,24 @@ def test_get_as_parameter_not_number():
     # Then Expected
     with pytest.raises(ValueError):
         test_parameter = get_as_parameter(test_parameter, 'test_parameter', PARAMETER_DETAILS)
+
+
+def test_dict_remains_unchanged():
+    expected_parameter_details = {
+        'test_parameter': {
+            'description': 'Test parameter',
+            'url': 'https://veryrealwebsite.com',
+            'value': 1.0,
+            'min': 0,
+            'max': np.Inf,
+            'fixed': True,
+        }
+    }
+    # When
+    test_parameter = 2.0
+
+    # Then
+    test_parameter = get_as_parameter(int(test_parameter), 'test_parameter', PARAMETER_DETAILS)
+
+    # Expected
+    assert_equal(expected_parameter_details['test_parameter'], PARAMETER_DETAILS['test_parameter'])


### PR DESCRIPTION
Consolidated `from_pars` and `default` into class constructor.

This is just a first step.  When we agree that this structure seems reasonable it we will be rolled out in the rest of the repo(s)

The `parameter_utils` module should probably be moved to `EasyCore`