### PR TITLE
139 prepare for magnetism refl1d

### DIFF
--- a/EasyReflectometry/calculators/refl1d/wrapper.py
+++ b/EasyReflectometry/calculators/refl1d/wrapper.py
@@ -10,9 +10,10 @@ from EasyReflectometry.experiment.resolution_functions import is_constant_resolu
 
 from ..wrapper_base import WrapperBase
 
-PADDING_RANGE = 3.5
-UPSCALE_FACTOR = 21
+RESOLUTION_PADDING = 3.5
+OVERSAMPLING_FACTOR = 21
 MAGNETISM = False
+ALL_POLARIZATIONS = False
 
 
 class Refl1dWrapper(WrapperBase):
@@ -30,7 +31,7 @@ class Refl1dWrapper(WrapperBase):
 
         :param name: The name of the layer
         """
-        if MAGNETISM:
+        if MAGNETISM:  # A test with hardcoded magnetism in all layers
             magnetism = names.Magnetism(rhoM=0.2, thetaM=270)
         else:
             magnetism = None
@@ -46,17 +47,6 @@ class Refl1dWrapper(WrapperBase):
             model.Stack(model.Slab(names.SLD(), thickness=0, interface=0)), name=str(name)
         )
         del self.storage['item'][name].stack[0]
-
-    def update_item(self, name: str, **kwargs):
-        """
-        Update a layer.
-
-        :param name: The item name
-        """
-        item = self.storage['item'][name]
-        for key in kwargs.keys():
-            ii = getattr(item, key)
-            setattr(ii, 'value', kwargs[key])
 
     def get_item_value(self, name: str, key: str) -> float:
         """
@@ -155,61 +145,43 @@ class Refl1dWrapper(WrapperBase):
         :param model_name: the model name
         :return: reflectivity calculated at q
         """
-        structure = model.Stack()
-        # -1 to reverse the order
-        for i in self.storage['model'][model_name]['items'][::-1]:
-            if i.repeat.value == 1:
-                # -1 to reverse the order
-                for j in range(len(i.stack))[::-1]:
-                    structure |= i.stack[j]
-            else:
-                stack = model.Stack()
-                # -1 to reverse the order
-                for j in range(len(i.stack))[::-1]:
-                    stack |= i.stack[j]
-                structure |= model.Repeat(stack, repeat=i.repeat.value)
-
-        argmin = np.argmin(q_array)
-        argmax = np.argmax(q_array)
-        dq_vector = self._resolution_function(q_array)
+        sample = _build_sample(self.storage, model_name)
+        dq_array = self._resolution_function(q_array)
 
         if is_constant_resolution_function(self._resolution_function):
             # Get percentage of Q and change from sigma to FWHM
-            dq_vector = dq_vector * q_array / 100 / (2 * np.sqrt(2 * np.log(2)))
+            dq_array = dq_array * q_array / 100 / (2 * np.sqrt(2 * np.log(2)))
 
-        if MAGNETISM:
-            xs = []
-            for _ in range(4):
-                q = names.QProbe(
-                    Q=q_array,
-                    dQ=dq_vector,
-                    intensity=self.storage['model'][model_name]['scale'],
-                    background=self.storage['model'][model_name]['bkg'],
-                )
-                q.calc_Qo = np.linspace(
-                    q_array[argmin] - PADDING_RANGE * dq_vector[argmin],
-                    q_array[argmax] + PADDING_RANGE * dq_vector[argmax],
-                    UPSCALE_FACTOR * len(q_array),
-                )
-                xs.append(q)
-            probe = names.PolarizedQProbe(xs=xs, name='polarized')
-
-            R = names.Experiment(probe=probe, sample=structure).reflectivity()[1]
+        if not MAGNETISM:
+            probe = _get_probe(
+                q_array=q_array,
+                dq_array=dq_array,
+                model_name=model_name,
+                storage=self.storage,
+                oversampling_factor=OVERSAMPLING_FACTOR,
+            )
+            _, reflectivity = names.Experiment(probe=probe, sample=sample).reflectivity()
         else:
-            q = names.QProbe(
-                Q=q_array,
-                dQ=dq_vector,
-                intensity=self.storage['model'][model_name]['scale'],
-                background=self.storage['model'][model_name]['bkg'],
+            polarized_probe = _get_polarized_probe(
+                q_array=q_array,
+                dq_array=dq_array,
+                model_name=model_name,
+                storage=self.storage,
+                oversampling_factor=OVERSAMPLING_FACTOR,
+                all_polarizations=ALL_POLARIZATIONS,
             )
-            q.calc_Qo = np.linspace(
-                q_array[argmin] - PADDING_RANGE * dq_vector[argmin],
-                q_array[argmax] + PADDING_RANGE * dq_vector[argmax],
-                UPSCALE_FACTOR * len(q_array),
-            )
-            R = names.Experiment(probe=q, sample=structure).reflectivity()[1]
+            polarized_reflectivity = names.Experiment(probe=polarized_probe, sample=sample).reflectivity()
 
-        return R
+            if ALL_POLARIZATIONS:
+                raise NotImplementedError('Polarized reflectivity not yet implemented')
+                _, reflectivity_pp = polarized_reflectivity[0]
+                _, reflectivity_pm = polarized_reflectivity[1]
+                _, reflectivity_mp = polarized_reflectivity[2]
+                _, reflectivity_mm = polarized_reflectivity[3]
+            else:
+                _, reflectivity = polarized_reflectivity[0]
+
+        return reflectivity
 
     def sld_profile(self, model_name: str) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -218,26 +190,82 @@ class Refl1dWrapper(WrapperBase):
         :param model_name: the model name
         :return: z and sld(z)
         """
-        structure = model.Stack()
-        # -1 to reverse the order
-        for i in self.storage['model'][model_name]['items'][::-1]:
-            if i.repeat.value == 1:
-                # -1 to reverse the order
-                for j in range(len(i.stack))[::-1]:
-                    structure |= i.stack[j]
-            else:
-                stack = model.Stack()
-                # -1 to reverse the order
-                for j in range(len(i.stack))[::-1]:
-                    stack |= i.stack[j]
-                structure |= model.Repeat(stack, repeat=i.repeat.value)
-
-        q = names.QProbe(
-            np.linspace(0.001, 0.3, 10),
-            np.linspace(0.001, 0.3, 10),
-            intensity=self.storage['model'][model_name]['scale'],
-            background=self.storage['model'][model_name]['bkg'],
+        sample = _build_sample(self.storage, model_name)
+        probe = _get_probe(
+            q_array=np.linspace(0.001, 0.3, 10),
+            dq_array=np.linspace(0.001, 0.3, 10),  # TODO why would we use a steadily increasing dq (resolution)?
+            model_name=model_name,
+            storage=self.storage,
         )
-        z, sld, _ = names.Experiment(probe=q, sample=structure).smooth_profile()
+        z, sld, _ = names.Experiment(probe=probe, sample=sample).smooth_profile()
         # -1 to reverse the order
         return z, sld[::-1]
+
+
+def _get_oversampling_q(q_array: np.ndarray, dq_array: np.ndarray, oversampling_factor: int) -> np.ndarray:
+    argmin = np.argmin(q_array)
+    argmax = np.argmax(q_array)
+    return np.linspace(
+        q_array[argmin] - RESOLUTION_PADDING * dq_array[argmin],  # get dq (resolution) corresponding to the smallest q
+        q_array[argmax] + RESOLUTION_PADDING * dq_array[argmax],  # get dq (resolution) corresponding to the largest q
+        oversampling_factor * len(q_array),
+    )
+
+
+def _get_probe(
+    q_array: np.ndarray,
+    dq_array: np.ndarray,
+    model_name: str,
+    storage: dict,
+    oversampling_factor: int = 1,
+) -> names.QProbe:
+    probe = names.QProbe(
+        Q=q_array,
+        dQ=dq_array,
+        intensity=storage['model'][model_name]['scale'],
+        background=storage['model'][model_name]['bkg'],
+    )
+    if oversampling_factor > 1:
+        probe.calc_Qo = _get_oversampling_q(q_array, dq_array, oversampling_factor)
+    return probe
+
+
+def _get_polarized_probe(
+    q_array: np.ndarray,
+    dq_array: np.ndarray,
+    model_name: str,
+    storage: dict,
+    oversampling_factor: int = 1,
+    all_polarizations: bool = False,
+) -> names.QProbe:
+    xs = []
+    for i in range(4):
+        if i == 0 or all_polarizations:
+            probe = _get_probe(
+                q_array=q_array,
+                dq_array=dq_array,
+                model_name=model_name,
+                storage=storage,
+                oversampling_factor=oversampling_factor,
+            )
+        else:
+            probe = None
+        xs.append(probe)
+    return names.PolarizedQProbe(xs=xs, name='polarized')
+
+
+def _build_sample(storage: dict, model_name: str) -> model.Stack:
+    sample = model.Stack()
+    # -1 to reverse the order
+    for i in storage['model'][model_name]['items'][::-1]:
+        if i.repeat.value == 1:
+            # -1 to reverse the order
+            for j in range(len(i.stack))[::-1]:
+                sample |= i.stack[j]
+        else:
+            stack = model.Stack()
+            # -1 to reverse the order
+            for j in range(len(i.stack))[::-1]:
+                stack |= i.stack[j]
+            sample |= model.Repeat(stack, repeat=i.repeat.value)
+    return sample

--- a/EasyReflectometry/calculators/refl1d/wrapper.py
+++ b/EasyReflectometry/calculators/refl1d/wrapper.py
@@ -203,11 +203,11 @@ class Refl1dWrapper(WrapperBase):
 
 
 def _get_oversampling_q(q_array: np.ndarray, dq_array: np.ndarray, oversampling_factor: int) -> np.ndarray:
-    argmin = np.argmin(q_array)
-    argmax = np.argmax(q_array)
+    argmin = np.argmin(q_array)  # index of the smallest q element
+    argmax = np.argmax(q_array)  # index of the largest q element
     return np.linspace(
-        q_array[argmin] - RESOLUTION_PADDING * dq_array[argmin],  # get dq (resolution) corresponding to the smallest q
-        q_array[argmax] + RESOLUTION_PADDING * dq_array[argmax],  # get dq (resolution) corresponding to the largest q
+        q_array[argmin] - RESOLUTION_PADDING * dq_array[argmin],  # dq element at the smallest q index
+        q_array[argmax] + RESOLUTION_PADDING * dq_array[argmax],  # dq element at the largest q index
         oversampling_factor * len(q_array),
     )
 

--- a/EasyReflectometry/calculators/refl1d/wrapper.py
+++ b/EasyReflectometry/calculators/refl1d/wrapper.py
@@ -174,10 +174,10 @@ class Refl1dWrapper(WrapperBase):
 
             if ALL_POLARIZATIONS:
                 raise NotImplementedError('Polarized reflectivity not yet implemented')
-                _, reflectivity_pp = polarized_reflectivity[0]
-                _, reflectivity_pm = polarized_reflectivity[1]
-                _, reflectivity_mp = polarized_reflectivity[2]
-                _, reflectivity_mm = polarized_reflectivity[3]
+                # _, reflectivity_pp = polarized_reflectivity[0]
+                # _, reflectivity_pm = polarized_reflectivity[1]
+                # _, reflectivity_mp = polarized_reflectivity[2]
+                # _, reflectivity_mm = polarized_reflectivity[3]
             else:
                 _, reflectivity = polarized_reflectivity[0]
 
@@ -192,8 +192,8 @@ class Refl1dWrapper(WrapperBase):
         """
         sample = _build_sample(self.storage, model_name)
         probe = _get_probe(
-            q_array=np.linspace(0.001, 0.3, 10),
-            dq_array=np.linspace(0.001, 0.3, 10),  # TODO why would we use a steadily increasing dq (resolution)?
+            q_array=np.array([1]),  # dummy value
+            dq_array=np.array([1]),  # dummy value
             model_name=model_name,
             storage=self.storage,
         )
@@ -238,7 +238,7 @@ def _get_polarized_probe(
     oversampling_factor: int = 1,
     all_polarizations: bool = False,
 ) -> names.QProbe:
-    xs = []
+    four_probes = []
     for i in range(4):
         if i == 0 or all_polarizations:
             probe = _get_probe(
@@ -250,8 +250,8 @@ def _get_polarized_probe(
             )
         else:
             probe = None
-        xs.append(probe)
-    return names.PolarizedQProbe(xs=xs, name='polarized')
+        four_probes.append(probe)
+    return names.PolarizedQProbe(xs=four_probes, name='polarized')
 
 
 def _build_sample(storage: dict, model_name: str) -> model.Stack:

--- a/EasyReflectometry/calculators/refnx/calculator.py
+++ b/EasyReflectometry/calculators/refnx/calculator.py
@@ -28,7 +28,6 @@ class Refnx(CalculatorBase):
     _model_link = {
         'scale': 'scale',
         'background': 'bkg',
-        'resolution': 'dq',
     }
 
     def __init__(self):

--- a/tests/calculators/refl1d/test_refl1d_wrapper.py
+++ b/tests/calculators/refl1d/test_refl1d_wrapper.py
@@ -315,7 +315,6 @@ def test_get_probe():
     assert all(probe.Q == q)
     assert all(probe.calc_Qo == q)
     assert all(probe.dQ == dq)
-    assert len(probe.calc_Qo) == len(q)
     assert probe.intensity.value == 10
     assert probe.background.value == 20
 
@@ -361,6 +360,23 @@ def test_get_polarized_probe():
     assert probe.xs[0].background.value == 20
 
 
+def test_get_polarized_probe_oversampling():
+    # When
+    q = np.linspace(1, 10, 10)
+    dq = np.linspace(0.01, 0.1, 10)
+    model_name = 'model_name'
+
+    storage = {'model': {model_name: {}}}
+    storage['model'][model_name]['scale'] = 10.0
+    storage['model'][model_name]['bkg'] = 20.0
+
+    # Then
+    probe = _get_polarized_probe(q_array=q, dq_array=dq, model_name=model_name, storage=storage, oversampling_factor=2)
+
+    # Then
+    assert len(probe.xs[0].calc_Qo) == 2 * len(q)
+
+
 def test_get_polarized_probe_polarization():
     # When
     q = np.linspace(1, 10, 10)
@@ -377,15 +393,14 @@ def test_get_polarized_probe_polarization():
         dq_array=dq,
         model_name=model_name,
         storage=storage,
-        oversampling_factor=2,
         all_polarizations=True,
     )
 
-    # Then
-    assert len(probe.xs[0].calc_Qo) == 2 * len(q)
-    assert len(probe.xs[1].calc_Qo) == 2 * len(q)
-    assert len(probe.xs[2].calc_Qo) == 2 * len(q)
-    assert len(probe.xs[3].calc_Qo) == 2 * len(q)
+    # Expect
+    assert len(probe.xs[0].calc_Qo) == len(q)
+    assert len(probe.xs[1].calc_Qo) == len(q)
+    assert len(probe.xs[2].calc_Qo) == len(q)
+    assert len(probe.xs[3].calc_Qo) == len(q)
 
 
 @patch('EasyReflectometry.calculators.refl1d.wrapper.model.Stack')

--- a/tests/calculators/refl1d/test_refl1d_wrapper.py
+++ b/tests/calculators/refl1d/test_refl1d_wrapper.py
@@ -408,11 +408,11 @@ def test_build_sample(mock_repeat, mock_stack):
     storage['model'][model_name]['items'].append(mock_item_2)
 
     # Then
-    sample = _build_sample(model_name=model_name, storage=storage)
+    _ = _build_sample(model_name=model_name, storage=storage)
 
     # Expect
     assert mock_stack.call_count == 2
     assert mock_repeat.call_count == 1
-    # TODO do asserts on sample
+    # TODO do asserts on sample returned by _build_sample
     # will probably use other build_sample function in future
     # difficult to test current implementation

--- a/tests/calculators/refnx/test_refnx_calculator.py
+++ b/tests/calculators/refnx/test_refnx_calculator.py
@@ -1,6 +1,7 @@
 """
 Tests for Refnx calculator.
 """
+
 __author__ = 'github.com/arm61'
 __version__ = '0.0.1'
 
@@ -24,7 +25,6 @@ class TestRefnx(unittest.TestCase):
         assert_equal(p._item_link['repetitions'], 'repeats')
         assert_equal(p._model_link['scale'], 'scale')
         assert_equal(p._model_link['background'], 'bkg')
-        assert_equal(p._model_link['resolution'], 'dq')
         assert_equal(p.name, 'refnx')
 
     def test_fit_func(self):


### PR DESCRIPTION
Move functionality used more than 1 time to private functions:
- `_get_probe`
- `_get_polarized_probe`
- `_get_oversampling`
- `_get_sample`

Made it possible to do a POC calculations with magnetism by setting `MAGNETISM=True`

Renamed constants to make it more clear what they represents.

Introduced new polarized probe that is needed for calculations with magnetism.  The results obtained from the "ordinary" probe and the polarized probe are not identical.  No work have been done yet to understand these differences.

Removed functionality that is no longer used:
- `'resolution': 'dq'` and `dq` in refnx
- `update_item` in refld