### PR TITLE
145 update easycore to easyscience

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: c9e6721
+_commit: 8bdcedc
 _src_path: gh:/EasyScience/EasyProjectTemplate
 description: A reflectometry python package built on the EasyScience framework.
 max_python: '3.12'

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -7,5 +7,5 @@ min_python: '3.9'
 orgname: EasyScience
 packagename: easyreflectometry
 prettyname: Easy Reflectometry Library
-projectname: EasyReflectometry
+projectname: easyreflectometry
 year: 2024

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: fd638f4
+_commit: c9e6721
 _src_path: gh:/EasyScience/EasyProjectTemplate
 description: A reflectometry python package built on the EasyScience framework.
 max_python: '3.12'
@@ -7,5 +7,5 @@ min_python: '3.9'
 orgname: EasyScience
 packagename: easyreflectometry
 prettyname: Easy Reflectometry Library
-projectname: EasyReflectometryLib
+projectname: EasyReflectometry
 year: 2024

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,10 +1,12 @@
-# This workflow will
-# - build developer documentation 
-# - push documentation to gh-pages branch of the same repository
+# This pipeline
+# - builds developer documentation
+# - pushes documentation to gh-pages branch of the same repository
 #
 # Deployment is handled by pages-build-deployment bot
+#
+# For more information see: https://docs.github.com/en/pages/getting-started-with-github-pages
 
-name: Build Documentation and Push to gh-pages Branch 
+name: Build Documentation and Push to gh-pages Branch
 
 # Controls when the workflow will run
 on:
@@ -26,6 +28,9 @@ jobs:
       uses: actions/checkout@master
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+    - name: Upgrade pip
+      run: |
+        python -m pip install --upgrade pip
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -34,7 +39,6 @@ jobs:
       run: |
         sudo apt install pandoc
         pip install . '.[dev,docs]'
-
     - name: Build and Commit
       uses: sphinx-notes/pages@master
       with:

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -1,6 +1,9 @@
 # This workflow integrates a collection of open source static analysis tools
-# with GitHub code scanning. For documentation, or to provide feedback, visit
-# https://github.com/github/ossar-action
+# with GitHub code scanning.
+#
+# For more information see: https://github.com/github/ossar-action
+
+
 name: OSSAR
 
 on:

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Run open source static analysis tools
     - name: Run OSSAR
-      uses: github/ossar-action@v1
+      uses: github/ossar-action@v2.0.0
       id: ossar
 
       # Upload results to the Security tab

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,6 +43,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Upgrade pip
+      run: |
+        python -m pip install --upgrade pip
+
     - name: Install dependencies
       run: pip install -e '.[dev]'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,7 @@
 #
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
+
 name: Publish Python Package
 
 # Controls when the workflow will run

--- a/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,6 +1,10 @@
-# This workflow will be verify that all PRs have at
-# least on the label: 'bugs', 'enhancement' before
-# they can be merged.
+# This workflow will
+# - verify that a PR has a known label before it can be merged.
+#
+# A PR is enforced to have one of the labels listed in the valid-labels input.
+#
+# For more information see: https://github.com/marketplace/actions/release-drafter
+
 
 name: Verify PR labels
 on:

--- a/.github/workflows/release-drafter-verify-pr-labels.yml
+++ b/.github/workflows/release-drafter-verify-pr-labels.yml
@@ -1,7 +1,6 @@
-# This workflow will
-# - verify that a PR has a known label before it can be merged.
-#
-# A label is needed for the release-drafter workflow to generate the notes.
+# This workflow will be verify that all PRs have at
+# least on the label: 'bugs', 'enhancement' before
+# they can be merged.
 
 name: Verify PR labels
 on:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,22 +1,16 @@
-# This workflow will
-# - draft a new release the next time a release is tagged.
-#
-# Uses the release-drafter.yml configuration file in the .github directory.
-# https://github.com/marketplace/actions/release-drafter
-
-
 name: Release Drafter
 
 on:
   push:
-    tags:
-      - 'v*'
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - pre-release
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,16 +1,22 @@
+# This workflow will
+# - draft a new release the next time a release is tagged.
+#
+# Uses the release-drafter.yml configuration file in the .github directory.
+# https://github.com/marketplace/actions/release-drafter
+
+
 name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - pre-release
+    tags:
+      - 'v*'
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 # What is EasyReflectometry?
 
-A reflectometry application and a python package built on the [`easyscience` framework](https://easyscience.software).
+A reflectometry python package and an application.
 
-This repo and information is about the `easyreflectometry` Python library, but a graphical user application is also available. 
-Find out about this APP at [`easyreflectometry.org`](https://easyreflectometry.org)
+This repo and documentation is about the `easyreflectometry` Python library that is built on the [`easyscience` framework](https://easyscience.software).
+To get more information about the application visit [`easyreflectometry.org`](https://easyreflectometry.org)
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Quality badge](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge)](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib)
 [![Docs badge](https://img.shields.io/badge/docs-built-blue)](http://docs.easyreflectometry.org)
 
-# What is EasyReflectometry?
+# About
 
 A reflectometry python package and an application.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Logo](https://github.com/easyScience/EasyReflectometryLib/raw/master/docs/src/_static/logo.png)
+[![CI badge](https://github.com/easyScience/EasyReflectometryLib/actions/workflows/python-ci.yml/badge.svg)](https://github.com/easyScience/easyReflectometryLib/actions/workflows/python-ci.yml)
 [![PyPI badge](http://img.shields.io/pypi/v/EasyReflectometryLib.svg)](https://pypi.python.org/pypi/EasyReflectometryLib)
 [![Coverage badge](https://codecov.io/gh/easyScience/EasyReflectometryLib/branch/master/graph/badge.svg?token=LcnB8AMGkw)](https://codecov.io/gh/easyScience/EasyReflectometryLib)
 [![Quality badge](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge)](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # What is EasyReflectometry?
 
-A reflectometry python package built on the [`easyscience` framework](https://easyscience.software).
+A reflectometry application and a python package built on the [`easyscience` framework](https://easyscience.software).
 
-This is information about the `easyreflectometry` Python library, but a graphical user application is also available. 
+This repo and information is about the `easyreflectometry` Python library, but a graphical user application is also available. 
 Find out about this APP at [`easyreflectometry.org`](https://easyreflectometry.org)
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+![Logo](https://github.com/easyScience/EasyReflectometryLib/raw/master/docs/src/_static/logo.png)
 [![PyPI badge](http://img.shields.io/pypi/v/EasyReflectometryLib.svg)](https://pypi.python.org/pypi/EasyReflectometryLib)
-[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
 
-# Easy Reflectometry
+# What is easyreflectometry?
 
-## About
+A reflectometry python package built on the [`easyscience` framework](https://easyscience.software).
 
-A reflectometry python package built on the [`EasyScience` framework](https://easyscience.software).
+This is information about the `easyreflectometry` Python library, but a graphical user application is also available. 
+Find out about this APP at [`easyreflectometry.org`](https://easyreflectometry.org)
 
-This is information about the `EasyReflectometry` Python library, but a graphical user application is also available. 
-Find out about that at [`easyreflectometry.org`](https://easyreflectometry.org)
-
-## Installation
+# Installation
 
 ```sh
-python -m pip install EasyReflectometryLib
+python -m pip install easyreflectometry
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A reflectometry python package and an application.
 
-This repo and documentation is about the `easyreflectometry` Python library that is built on the [`easyscience` framework](https://easyscience.software).
+This repo and documentation is for the `easyreflectometry` Python package that is built on the `easyscience` [framework](https://easyscience.software).
 To get more information about the application visit [`easyreflectometry.org`](https://easyreflectometry.org)
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![Logo](https://github.com/easyScience/EasyReflectometryLib/raw/master/docs/src/_static/logo.png)
 [![PyPI badge](http://img.shields.io/pypi/v/EasyReflectometryLib.svg)](https://pypi.python.org/pypi/EasyReflectometryLib)
+[![Coverage badge](https://codecov.io/gh/easyScience/EasyReflectometryLib/branch/master/graph/badge.svg?token=LcnB8AMGkw)](https://codecov.io/gh/easyScience/EasyReflectometryLib)
+[![Quality badge](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge)](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib)
 
-# What is easyreflectometry?
+# What is EasyReflectometry?
 
 A reflectometry python package built on the [`easyscience` framework](https://easyscience.software).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![PyPI badge](http://img.shields.io/pypi/v/EasyReflectometryLib.svg)](https://pypi.python.org/pypi/EasyReflectometryLib)
 [![Coverage badge](https://codecov.io/gh/easyScience/EasyReflectometryLib/branch/master/graph/badge.svg?token=LcnB8AMGkw)](https://codecov.io/gh/easyScience/EasyReflectometryLib)
 [![Quality badge](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge)](https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib)
+[![Docs badge](https://img.shields.io/badge/docs-built-blue)](http://docs.easyreflectometry.org)
 
 # What is EasyReflectometry?
 

--- a/docs/src/calculators.rst
+++ b/docs/src/calculators.rst
@@ -1,8 +1,8 @@
 Calculators & Optimisation
 ==========================
 
-:py:mod:`EasyReflectometry` is built on the :py:mod:`EasyScience` framework which facilities the use of a range of different reflectometry calculation engines and optimiser solutions. 
-Currently, :py:mod:`EasyReflectometry` can offer two different calculation engines, namely:
+:py:mod:`easyreflectometry` is built on the :py:mod:`easyscience` framework which facilities the use of a range of different reflectometry calculation engines and optimiser solutions. 
+Currently, :py:mod:`easyreflectometry` can offer two different calculation engines, namely:
 
 * `refnx`_
 * `Refl1D`_

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.mathjax',
     'sphinx_autodoc_typehints',
-    'nbsphinx'
+    'nbsphinx',
+    'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/src/experiment/experiment.rst
+++ b/docs/src/experiment/experiment.rst
@@ -1,16 +1,16 @@
 Experiment
 ==========
 
-The main component of an experiment in :py:mod:`easyreflectometry` is the `Model`. 
-This is a description of the `sample` and the environment in which the experiment is performed. 
-The `Model` is used to calculate the reflectivity of the `Sample` at a given set of angles (Q-points).
-The `resolution_functions` are used to quantify the experimental uncertainties in wavelength and angle, allowing the `Model`` to accurately describe the data.
+The main component of an experiment in :py:mod:`easyreflectometry` is the :py:class:`Model`. 
+This is a description of the :py:class:`Sample` and the environment in which the experiment is performed. 
+The :py:class:`Model` is used to calculate the reflectivity of the :py:class:`Sample` at a given set of angles (Q-points).
+The :py:func:`resolution_functions` are used to quantify the experimental uncertainties in wavelength and angle, allowing the :py:class:`Model` to accurately describe the data.
 
 :py:class:`Model`
 -----------------
 
-A `Model` instance contains a `Sample` and variables describing experimental settings.
-To be able to compute reflectivities it is also necessary to have a `Calculator` (interface).
+A :py:class:`Model` instance contains a :py:class:`Sample` and variables describing experimental settings.
+To be able to compute reflectivities it is also necessary to have a :py:class:`Calculator` (interface).
 
 .. code-block:: python 
 
@@ -28,13 +28,13 @@ To be able to compute reflectivities it is also necessary to have a `Calculator`
    interface = CalculatorFactory()
    model.interface = interface
 
-This will create a :py:class:`Model` instance with the `default_sample` and the environment variables `scale` factor set to 1.0 and a `background` of 1e-6.
-Following the `interface` is set to the default calculator that is `Refnx`.
+This will create a :py:class:`Model` instance with the :py:attr:`default_sample` and the environment variables :py:attr:`scale` factor set to 1.0 and a :py:attr:`background` of 1e-6.
+Following the :py:attr:`interface` is set to the default calculator that is :py:class:`Refnx`.
 
 
 :py:mod:`resolution_functions`
 ------------------------------
-A resolution function enables the `easyreflectometry` model to incorporate the experimental uncertainties in wavelength and incident angle into the model.
+A resolution function enables the :py:mod:`easyreflectometry` model to incorporate the experimental uncertainties in wavelength and incident angle into the model.
 In its essence the resolution function controls the smearing to apply when determing the reflectivtiy at a given Q-point.
 For a given Q-point the smearing to apply is given as a weighted average of the neighboring Q-point, which weigths are by a normal distribution.
 This normal distribution is then defined by a Q-point dependent Full Width at the Half Maximum (FWHM) that is given by the resolution function.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,31 +1,5 @@
-.. image:: https://github.com/easyScience/EasyReflectometryLib/raw/master/docs/src/_static/logo.png
-        :target: https://easyscience.github.io/EasyReflectometryLib/
-
-|
-
-.. image:: https://github.com/easyScience/EasyReflectometryLib/actions/workflows/python-ci.yml/badge.svg
-        :target: https://github.com/easyScience/easyReflectometryLib/actions/workflows/python-ci.yml
-.. image:: https://codecov.io/gh/easyScience/EasyReflectometryLib/branch/master/graph/badge.svg?token=LcnB8AMGkw
-        :target: https://codecov.io/gh/easyScience/EasyReflectometryLib
-.. image:: https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib/badge
-        :target: https://www.codefactor.io/repository/github/easyscience/easyreflectometrylib
-        :alt: CodeFactor
-.. image:: https://img.shields.io/badge/docs-built-blue
-        :target: http://docs.easyreflectometry.org
-        :alt: Docs
-
-|
-
-What is EasyReflectometry?
---------------------------
-
-EasyReflectometry is a reflectometry analysis package built on the `EasyScience framework`_.
-
-This is the documentation for the EasyReflectometry Python library, but a graphical user application is also available. 
-Find out about that graphical user interface `EasyReflectometry GUI`_.
-
-.. _`EasyScience framework`: https://easyscience.software
-.. _`EasyReflectometry GUI`: https://easyreflectometry.org
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
 
 .. toctree::
    :hidden:

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -8,7 +8,7 @@ Installation
 Stable release
 --------------
 
-To install EasyReflectometry, run this command in your terminal:
+To install :py:mod:`easyreflectometry`, run this command in your terminal:
 
 .. code-block:: console
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -12,7 +12,7 @@ To install EasyReflectometry, run this command in your terminal:
 
 .. code-block:: console
 
-    $ pip install EasyReflectometryLib
+    $ pip install easyreflectometry
 
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.

--- a/docs/src/sample/material_library.rst
+++ b/docs/src/sample/material_library.rst
@@ -3,7 +3,7 @@ Materials
 
 In order to support a wide range of applications (and to build complex `assemblies`_) there are a few different types of material that can be utilised in :py:mod:`easyreflectometry`. 
 These can include constraints or enabel the user to define the material based on chemical or physical properties. 
-Full API documentation for the :py:mod:`EasyReflectoemtry.sample.elements.material` mdoule is also available, but here we will give some simple uses for them. 
+Full API documentation for the :py:mod:`easyreflectometry.sample.elements.material` mdoule is also available, but here we will give some simple uses for them. 
 
 :py:class:`Material`
 --------------------

--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -2,7 +2,7 @@
 Usage
 =====
 
-To use EasyReflectometry in a project::
+To use :py:mod:`easyreflectometry` in a project::
 
     import easyreflectometry
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 enabled = true
 
 [project]
-name = "EasyReflectometryLib"
+name = "easyreflectometry"
 dynamic = ["version"]
 description = "A reflectometry python package built on the EasyScience framework."
 readme = "README.md"
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.9,<3.12"
 dependencies = [
-    "easyScienceCore>=0.3.1",
+    "easyscience>=0.6.0",
     "scipp>=23.12.0",
     "refnx>=0.1.15",
     "refl1d>=0.8.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "yapf>=0.31.0",
 ]
 docs = [
+    "myst_parser",
     "nbsphinx",
     "sphinx_book_theme",
     "sphinx_autodoc_typehints",

--- a/src/easyreflectometry/calculators/bornagain/calculator.py
+++ b/src/easyreflectometry/calculators/bornagain/calculator.py
@@ -1,12 +1,12 @@
 __author__ = 'github.com/arm61'
 
 import numpy as np
-from easyCore.Objects.Inferface import ItemContainer
 from easyreflectometry.experiment import Model
 from easyreflectometry.sample import Layer
 from easyreflectometry.sample import Material
 from easyreflectometry.sample import MaterialMixture
 from easyreflectometry.sample import Multilayer
+from easyscience.Objects.Inferface import ItemContainer
 
 from ..calculator_base import CalculatorBase
 from .wrapper import BornAgainWrapper

--- a/src/easyreflectometry/calculators/calculator_base.py
+++ b/src/easyreflectometry/calculators/calculator_base.py
@@ -4,8 +4,8 @@ from abc import ABCMeta
 from typing import Callable
 
 import numpy as np
-from easyCore.Objects.core import ComponentSerializer
-from easyCore.Objects.Inferface import ItemContainer
+from easyscience.Objects.core import ComponentSerializer
+from easyscience.Objects.Inferface import ItemContainer
 
 from easyreflectometry.experiment import Model
 from easyreflectometry.sample import BaseAssembly

--- a/src/easyreflectometry/calculators/factory.py
+++ b/src/easyreflectometry/calculators/factory.py
@@ -1,6 +1,6 @@
 __author__ = 'github.com/wardsimon'
 
-from easyCore.Objects.Inferface import InterfaceFactoryTemplate
+from easyscience.Objects.Inferface import InterfaceFactoryTemplate
 
 from easyreflectometry.calculators import CalculatorBase
 

--- a/src/easyreflectometry/experiment/model.py
+++ b/src/easyreflectometry/experiment/model.py
@@ -8,8 +8,8 @@ from typing import Union
 
 import numpy as np
 import yaml
-from easyCore.Objects.ObjectClasses import BaseObj
-from easyCore.Objects.ObjectClasses import Parameter
+from easyscience.Objects.ObjectClasses import BaseObj
+from easyscience.Objects.ObjectClasses import Parameter
 
 from easyreflectometry.experiment.resolution_functions import is_percentage_fhwm_resolution_function
 from easyreflectometry.parameter_utils import get_as_parameter

--- a/src/easyreflectometry/fitting.py
+++ b/src/easyreflectometry/fitting.py
@@ -2,14 +2,14 @@ __author__ = 'github.com/arm61'
 
 import numpy as np
 import scipp as sc
-from easyCore.Fitting.Fitting import MultiFitter as easyFitter
+from easyscience.Fitting.Fitting import MultiFitter as easyFitter
 
 from easyreflectometry.experiment import Model
 
 
 class Fitter:
     def __init__(self, *args: Model):
-        r"""A convinence class for the :py:class:`easyCore.Fitting.Fitting`
+        r"""A convinence class for the :py:class:`easyscience.Fitting.Fitting`
         which will populate the :py:class:`sc.DataGroup` appropriately
         after the fitting is performed.
 

--- a/src/easyreflectometry/parameter_utils.py
+++ b/src/easyreflectometry/parameter_utils.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from numbers import Number
 from typing import Union
 
-from easyCore.Objects.ObjectClasses import Parameter
+from easyscience.Objects.ObjectClasses import Parameter
 
 
 def get_as_parameter(name: str, value: Union[Parameter, Number, None], default_dict: dict) -> Parameter:

--- a/src/easyreflectometry/sample/assemblies/base_assembly.py
+++ b/src/easyreflectometry/sample/assemblies/base_assembly.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Optional
 
-from easyCore.Fitting.Constraints import ObjConstraint
+from easyscience.Fitting.Constraints import ObjConstraint
 
 from ..base_core import BaseCore
 from ..elements.layers.layer import Layer

--- a/src/easyreflectometry/sample/assemblies/repeating_multilayer.py
+++ b/src/easyreflectometry/sample/assemblies/repeating_multilayer.py
@@ -1,7 +1,7 @@
 from typing import Union
 
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ..elements.layers.layer import Layer
 from ..elements.layers.layer_collection import LayerCollection

--- a/src/easyreflectometry/sample/assemblies/surfactant_layer.py
+++ b/src/easyreflectometry/sample/assemblies/surfactant_layer.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
-from easyCore.Fitting.Constraints import ObjConstraint
-from easyCore.Objects.ObjectClasses import Parameter
+from easyscience.Fitting.Constraints import ObjConstraint
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ..elements.layers.layer_area_per_molecule import LayerAreaPerMolecule
 from ..elements.layers.layer_collection import LayerCollection

--- a/src/easyreflectometry/sample/base_core.py
+++ b/src/easyreflectometry/sample/base_core.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 import yaml
-from easyCore.Objects.ObjectClasses import BaseObj
+from easyscience.Objects.ObjectClasses import BaseObj
 
 
 class BaseCore(BaseObj):

--- a/src/easyreflectometry/sample/base_element_collection.py
+++ b/src/easyreflectometry/sample/base_element_collection.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import yaml
-from easyCore.Objects.Groups import BaseCollection
+from easyscience.Objects.Groups import BaseCollection
 
 SIZE_DEFAULT_COLLECTION = 2
 

--- a/src/easyreflectometry/sample/elements/layers/layer.py
+++ b/src/easyreflectometry/sample/elements/layers/layer.py
@@ -2,8 +2,8 @@ __author__ = 'github.com/arm61'
 from typing import Union
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ...base_core import BaseCore
 from ..materials.material import Material

--- a/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -1,11 +1,11 @@
 from typing import Union
 
 import numpy as np
-from easyCore.Fitting.Constraints import FunctionalConstraint
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
 from easyreflectometry.special.calculations import area_per_molecule_to_scattering_length_density
 from easyreflectometry.special.calculations import neutron_scattering_length
+from easyscience.Fitting.Constraints import FunctionalConstraint
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ..materials.material import Material
 from ..materials.material_solvated import DEFAULTS as MATERIAL_SOLVATED_DEFAULTS

--- a/src/easyreflectometry/sample/elements/materials/material.py
+++ b/src/easyreflectometry/sample/elements/materials/material.py
@@ -3,8 +3,8 @@ __author__ = 'github.com/arm61'
 from typing import Union
 
 import numpy as np
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ...base_core import BaseCore
 

--- a/src/easyreflectometry/sample/elements/materials/material_density.py
+++ b/src/easyreflectometry/sample/elements/materials/material_density.py
@@ -1,12 +1,12 @@
 from typing import Union
 
 import numpy as np
-from easyCore.Fitting.Constraints import FunctionalConstraint
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
 from easyreflectometry.special.calculations import density_to_sld
 from easyreflectometry.special.calculations import molecular_weight
 from easyreflectometry.special.calculations import neutron_scattering_length
+from easyscience.Fitting.Constraints import FunctionalConstraint
+from easyscience.Objects.ObjectClasses import Parameter
 
 from .material import DEFAULTS as MATERIAL_DEFAULTS
 from .material import Material

--- a/src/easyreflectometry/sample/elements/materials/material_mixture.py
+++ b/src/easyreflectometry/sample/elements/materials/material_mixture.py
@@ -1,9 +1,9 @@
 from typing import Union
 
-from easyCore.Fitting.Constraints import FunctionalConstraint
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
 from easyreflectometry.special.calculations import weighted_average
+from easyscience.Fitting.Constraints import FunctionalConstraint
+from easyscience.Objects.ObjectClasses import Parameter
 
 from ...base_core import BaseCore
 from .material import DEFAULTS as MATERIAL_DEFAULTS

--- a/src/easyreflectometry/sample/elements/materials/material_solvated.py
+++ b/src/easyreflectometry/sample/elements/materials/material_solvated.py
@@ -1,7 +1,7 @@
 from typing import Union
 
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.parameter_utils import get_as_parameter
+from easyscience.Objects.ObjectClasses import Parameter
 
 from .material import Material
 from .material_mixture import MaterialMixture

--- a/src/easyreflectometry/sample/sample.py
+++ b/src/easyreflectometry/sample/sample.py
@@ -5,7 +5,7 @@ __author__ = 'github.com/arm61'
 from typing import Union
 
 import yaml
-from easyCore.Objects.Groups import BaseCollection
+from easyscience.Objects.Groups import BaseCollection
 
 from .assemblies.base_assembly import BaseAssembly
 from .assemblies.multilayer import Multilayer

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Easyscience contributors (https://github.com/EasyScience)
+import easyreflectometry as pkg
+
+
+def test_has_version():
+    assert hasattr(pkg, '__version__') # noqa S101

--- a/tests/sample/elements/materials/test_material_solvated.py
+++ b/tests/sample/elements/materials/test_material_solvated.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock
 import easyreflectometry.sample.elements.materials.material_mixture
 import easyreflectometry.sample.elements.materials.material_solvated
 import pytest
-from easyCore.Objects.ObjectClasses import Parameter
 from easyreflectometry.sample.elements.materials.material import Material
 from easyreflectometry.sample.elements.materials.material_solvated import MaterialSolvated
+from easyscience.Objects.ObjectClasses import Parameter
 
 
 class TestMaterialSolvated:


### PR DESCRIPTION
This PR:

Change from `easyCore` to `easyscience` 

In various comments, changed package name to all small caps:
`easyreflectometry`

Minor updates to documentation

Pull in updates from the project template
- pipelines

When Merged a release 1.0.0 will be made 