### PR TITLE
New parameter and numpy2

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Pandoc, repo and dependencies
       run: |
         sudo apt install pandoc

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies and build
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11','3.12']
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install dependencies and build
       run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.9, 3.10, and 3.11, and for PyPy. Check
+3. The pull request should work for Python, 3.10, 3.11 and 3.12, and for PyPy. Check
    https://travis-ci.com/easyScience/EasyReflectometryLib/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,41 +26,44 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha"
 ]
+
 requires-python = ">=3.10,<3.13"
+
 dependencies = [
-    "easyscience",
-    "scipp>=23.12.0",
-    "refnx>=0.1.15",
+    "easyscience==1.3.0",
+    "scipp==25.2.0",
+    "refnx==0.1.52",
     "refl1d[webview]==1.0.0a12",
-    "orsopy>=0.0.4",
-    "xhtml2pdf>=0.2.16"
+    "orsopy==1.2.1",
+    "xhtml2pdf==0.2.17",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "build",
-    "codecov>=2.1.11",
-    "coverage",
-    "coveralls",
-    "flake8>=6.0.0",
-    "ipykernel",
-    "jupyter>=1.0.0",
-    "jupyterlab",
-    "plopp",
-    "pooch",
-    "pytest>=5.2",
-    "pytest-cov>=3.0.0",
-    "ruff",
-    "toml>=0.10",
-    "yapf>=0.31.0",
+    "build==1.2.2.post1",
+    "codecov==2.1.13",
+    "coverage==7.7.0",
+    "coveralls==4.0.1",
+    "flake8==7.1.2",
+    "ipykernel==6.29.5",
+    "jupyter==1.1.1",
+    "jupyterlab==4.3.6",
+    "plopp==25.3.0",
+    "pooch==1.8.2",
+    "pytest==8.3.5",
+    "pytest-cov==6.0.0",
+    "ruff==0.11.0",
+    "toml==0.10.2",
+    "yapf==0.43.0",
 ]
+
 docs = [
-    "myst_parser",
-    "nbsphinx",
-    "sphinx_autodoc_typehints",
-    "sphinx_book_theme",
-    "sphinx-copybutton",
-    "toml"
+    "myst_parser==4.0.1",
+    "nbsphinx==0.9.7",
+    "sphinx_autodoc_typehints==3.0.1",
+    "sphinx_book_theme==1.1.4",
+    "sphinx-copybutton==0.5.2",
+    "toml==0.10.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "easyscience @git+https://github.com/EasyScience/EasyScience@develop",
+    "easyscience",
     "scipp>=23.12.0",
     "refnx>=0.1.15",
     "refl1d[webview]==1.0.0a12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "easyscience @git+https://github.com/EasyScience/EasyScience@remove_old_parameter",
+    "easyscience @git+https://github.com/EasyScience/EasyScience@develop",
     "scipp>=23.12.0",
     "refnx>=0.1.15",
     "refl1d[webview]==1.0.0a12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,12 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha"
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "easyscience @git+https://github.com/EasyScience/EasyScience@remove_old_parameter",
     "scipp>=23.12.0",
@@ -130,10 +129,9 @@ force-single-line = true
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py{3.9,3.10,3.11,3.12}
+envlist = py{3.10,3.11,3.12}
 [gh-actions]
 python =
-        3.9: py39
         3.10: py310
         3.11: py311
         3.12: py312

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,11 @@ classifiers = [
 ]
 requires-python = ">=3.9,<3.13"
 dependencies = [
-    "easyscience>=1.2.0",
+    "easyscience @git+https://github.com/EasyScience/EasyScience@remove_old_parameter",
     "scipp>=23.12.0",
     "refnx>=0.1.15",
-    "refl1d",
+    "refl1d[webview]==1.0.0a12",
     "orsopy>=0.0.4",
-    "pint==0.23", # Only to ensure that unit is reported as dimensionless rather than empty string
     "xhtml2pdf>=0.2.16"
 ]
 

--- a/src/easyreflectometry/calculators/refl1d/wrapper.py
+++ b/src/easyreflectometry/calculators/refl1d/wrapper.py
@@ -3,8 +3,9 @@ __author__ = 'github.com/arm61'
 from typing import Tuple
 
 import numpy as np
-from refl1d import model
+# from refl1d import model
 from refl1d import names
+from refl1d.sample.layers import Repeat
 
 from easyreflectometry.model import PercentageFwhm
 
@@ -34,7 +35,7 @@ class Refl1dWrapper(WrapperBase):
             magnetism = names.Magnetism(rhoM=0.0, thetaM=0.0)
         else:
             magnetism = None
-        self.storage['layer'][name] = model.Slab(name=str(name), magnetism=magnetism)
+        self.storage['layer'][name] = names.Slab(name=str(name), magnetism=magnetism)
 
     def create_item(self, name: str):
         """
@@ -42,8 +43,8 @@ class Refl1dWrapper(WrapperBase):
 
         :param name: The name of the item
         """
-        self.storage['item'][name] = model.Repeat(
-            model.Stack(model.Slab(names.SLD(), thickness=0, interface=0)), name=str(name)
+        self.storage['item'][name] = Repeat(
+            names.Stack(names.Slab(names.SLD(), thickness=0, interface=0)), name=str(name)
         )
         del self.storage['item'][name].stack[0]
 
@@ -267,8 +268,8 @@ def _get_polarized_probe(
     return names.PolarizedQProbe(xs=four_probes, name='polarized')
 
 
-def _build_sample(storage: dict, model_name: str) -> model.Stack:
-    sample = model.Stack()
+def _build_sample(storage: dict, model_name: str) -> names.Stack:
+    sample = names.Stack()
     # -1 to reverse the order
     for i in storage['model'][model_name]['items'][::-1]:
         if i.repeat.value == 1:
@@ -276,9 +277,9 @@ def _build_sample(storage: dict, model_name: str) -> model.Stack:
             for j in range(len(i.stack))[::-1]:
                 sample |= i.stack[j]
         else:
-            stack = model.Stack()
+            stack = names.Stack()
             # -1 to reverse the order
             for j in range(len(i.stack))[::-1]:
                 stack |= i.stack[j]
-            sample |= model.Repeat(stack, repeat=i.repeat.value)
+            sample |= Repeat(stack, repeat=i.repeat.value)
     return sample

--- a/src/easyreflectometry/calculators/refl1d/wrapper.py
+++ b/src/easyreflectometry/calculators/refl1d/wrapper.py
@@ -67,7 +67,7 @@ class Refl1dWrapper(WrapperBase):
         :param key: The given value keys
         """
         if key in ['magnetism_rhoM', 'magnetism_thetaM']:
-            return getattr(self.storage['layer'][name].magnetism, key.split('_')[-1])
+            return getattr(self.storage['layer'][name].magnetism, key.split('_')[-1]).value #TODO: check if we want to return the raw value or the full Parameter  # noqa: E501
         return super().get_layer_value(name, key)
 
     def create_model(self, name: str):

--- a/src/easyreflectometry/calculators/refl1d/wrapper.py
+++ b/src/easyreflectometry/calculators/refl1d/wrapper.py
@@ -3,7 +3,6 @@ __author__ = 'github.com/arm61'
 from typing import Tuple
 
 import numpy as np
-# from refl1d import model
 from refl1d import names
 from refl1d.sample.layers import Repeat
 

--- a/src/easyreflectometry/model/model.py
+++ b/src/easyreflectometry/model/model.py
@@ -26,7 +26,7 @@ DEFAULTS = {
         'url': 'https://github.com/reflectivity/edu_outreach/blob/master/refl_maths/paper.tex',
         'value': 1.0,
         'min': 0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
     'background': {
@@ -34,7 +34,7 @@ DEFAULTS = {
         'url': 'https://github.com/reflectivity/edu_outreach/blob/master/refl_maths/paper.tex',
         'value': 1e-8,
         'min': 0.0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
     'resolution': {

--- a/src/easyreflectometry/model/model.py
+++ b/src/easyreflectometry/model/model.py
@@ -9,7 +9,7 @@ from typing import Union
 
 import numpy as np
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 from easyscience.Objects.ObjectClasses import BaseObj
 
 from easyreflectometry.sample import BaseAssembly

--- a/src/easyreflectometry/model/model.py
+++ b/src/easyreflectometry/model/model.py
@@ -9,8 +9,8 @@ from typing import Union
 
 import numpy as np
 from easyscience import global_object
-from easyscience.Objects.variable import Parameter
 from easyscience.Objects.ObjectClasses import BaseObj
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.sample import BaseAssembly
 from easyreflectometry.sample import Sample

--- a/src/easyreflectometry/project.py
+++ b/src/easyreflectometry/project.py
@@ -11,7 +11,7 @@ import numpy as np
 from easyscience import global_object
 from easyscience.fitting import AvailableMinimizers
 from easyscience.fitting.fitter import DEFAULT_MINIMIZER
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 from scipp import DataGroup
 
 from easyreflectometry.calculators import CalculatorFactory

--- a/src/easyreflectometry/sample/assemblies/repeating_multilayer.py
+++ b/src/easyreflectometry/sample/assemblies/repeating_multilayer.py
@@ -2,7 +2,7 @@ from typing import Optional
 from typing import Union
 
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.utils import get_as_parameter
 

--- a/src/easyreflectometry/sample/assemblies/surfactant_layer.py
+++ b/src/easyreflectometry/sample/assemblies/surfactant_layer.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from easyscience import global_object
 from easyscience.Constraints import ObjConstraint
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from ..collections.layer_collection import LayerCollection
 from ..elements.layers.layer_area_per_molecule import LayerAreaPerMolecule

--- a/src/easyreflectometry/sample/elements/layers/layer.py
+++ b/src/easyreflectometry/sample/elements/layers/layer.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import numpy as np
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.utils import get_as_parameter
 

--- a/src/easyreflectometry/sample/elements/layers/layer.py
+++ b/src/easyreflectometry/sample/elements/layers/layer.py
@@ -18,7 +18,7 @@ DEFAULTS = {
         'value': 10.0,
         'unit': 'angstrom',
         'min': 0.0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
     'roughness': {
@@ -27,7 +27,7 @@ DEFAULTS = {
         'value': 3.3,
         'unit': 'angstrom',
         'min': 0.0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
 }

--- a/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -4,7 +4,7 @@ from typing import Union
 import numpy as np
 from easyscience import global_object
 from easyscience.Constraints import FunctionalConstraint
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.special.calculations import area_per_molecule_to_scattering_length_density
 from easyreflectometry.special.calculations import neutron_scattering_length

--- a/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
+++ b/src/easyreflectometry/sample/elements/layers/layer_area_per_molecule.py
@@ -31,8 +31,8 @@ DEFAULTS = {
         'url': 'https://www.ncnr.nist.gov/resources/activation/',
         'value': 4.186,
         'unit': 'angstrom',
-        'min': -np.Inf,
-        'max': np.Inf,
+        'min': -np.inf,
+        'max': np.inf,
         'fixed': True,
     },
     'isl': {
@@ -40,8 +40,8 @@ DEFAULTS = {
         'url': 'https://www.ncnr.nist.gov/resources/activation/',
         'value': 0.0,
         'unit': 'angstrom',
-        'min': -np.Inf,
-        'max': np.Inf,
+        'min': -np.inf,
+        'max': np.inf,
         'fixed': True,
     },
 }

--- a/src/easyreflectometry/sample/elements/materials/material.py
+++ b/src/easyreflectometry/sample/elements/materials/material.py
@@ -17,8 +17,8 @@ DEFAULTS = {
         'url': 'https://www.ncnr.nist.gov/resources/activation/',
         'value': 4.186,
         'unit': '1 / angstrom^2',
-        'min': -np.Inf,
-        'max': np.Inf,
+        'min': -np.inf,
+        'max': np.inf,
         'fixed': True,
     },
     'isld': {
@@ -26,8 +26,8 @@ DEFAULTS = {
         'url': 'https://www.ncnr.nist.gov/resources/activation/',
         'value': 0.0,
         'unit': '1 / angstrom^2',
-        'min': -np.Inf,
-        'max': np.Inf,
+        'min': -np.inf,
+        'max': np.inf,
         'fixed': True,
     },
 }

--- a/src/easyreflectometry/sample/elements/materials/material.py
+++ b/src/easyreflectometry/sample/elements/materials/material.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import numpy as np
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.utils import get_as_parameter
 

--- a/src/easyreflectometry/sample/elements/materials/material_density.py
+++ b/src/easyreflectometry/sample/elements/materials/material_density.py
@@ -4,7 +4,7 @@ from typing import Union
 import numpy as np
 from easyscience import global_object
 from easyscience.Constraints import FunctionalConstraint
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.special.calculations import density_to_sld
 from easyreflectometry.special.calculations import molecular_weight

--- a/src/easyreflectometry/sample/elements/materials/material_density.py
+++ b/src/easyreflectometry/sample/elements/materials/material_density.py
@@ -22,7 +22,7 @@ DEFAULTS = {
         'value': 2.33,
         'unit': 'gram / centimeter ** 3',
         'min': 0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
     'molecular_weight': {
@@ -30,8 +30,8 @@ DEFAULTS = {
         'url': 'https://en.wikipedia.org/wiki/Molecular_mass',
         'value': 28.02,
         'unit': 'g / mole',
-        'min': -np.Inf,
-        'max': np.Inf,
+        'min': -np.inf,
+        'max': np.inf,
         'fixed': True,
     },
 }

--- a/src/easyreflectometry/sample/elements/materials/material_mixture.py
+++ b/src/easyreflectometry/sample/elements/materials/material_mixture.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from easyscience import global_object
 from easyscience.Constraints import FunctionalConstraint
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.special.calculations import weighted_average
 from easyreflectometry.utils import get_as_parameter

--- a/src/easyreflectometry/sample/elements/materials/material_solvated.py
+++ b/src/easyreflectometry/sample/elements/materials/material_solvated.py
@@ -2,7 +2,7 @@ from typing import Optional
 from typing import Union
 
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 from easyreflectometry.utils import get_as_parameter
 

--- a/src/easyreflectometry/utils.py
+++ b/src/easyreflectometry/utils.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import yaml
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 
 def get_as_parameter(

--- a/tests/calculators/refl1d/test_refl1d_wrapper.py
+++ b/tests/calculators/refl1d/test_refl1d_wrapper.py
@@ -425,8 +425,8 @@ def test_get_polarized_probe_polarization():
     assert len(probe.xs[3].calc_Qo) == len(q)
 
 
-@patch('easyreflectometry.calculators.refl1d.wrapper.model.Stack')
-@patch('easyreflectometry.calculators.refl1d.wrapper.model.Repeat')
+@patch('easyreflectometry.calculators.refl1d.wrapper.names.Stack')
+@patch('easyreflectometry.calculators.refl1d.wrapper.Repeat')
 def test_build_sample(mock_repeat, mock_stack):
     # When
     mock_item_1 = MagicMock()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -37,13 +37,13 @@ class TestModel(unittest.TestCase):
         assert_equal(str(p.scale.unit), 'dimensionless')
         assert_equal(p.scale.value, 1.0)
         assert_equal(p.scale.min, 0.0)
-        assert_equal(p.scale.max, np.Inf)
+        assert_equal(p.scale.max, np.inf)
         assert_equal(p.scale.fixed, True)
         assert_equal(p.background.display_name, 'background')
         assert_equal(str(p.background.unit), 'dimensionless')
         assert_equal(p.background.value, 1.0e-8)
         assert_equal(p.background.min, 0.0)
-        assert_equal(p.background.max, np.Inf)
+        assert_equal(p.background.max, np.inf)
         assert_equal(p.background.fixed, True)
         assert p._resolution_function.smearing([1]) == 5.0
         assert p._resolution_function.smearing([100]) == 5.0
@@ -73,13 +73,13 @@ class TestModel(unittest.TestCase):
         assert_equal(str(mod.scale.unit), 'dimensionless')
         assert_equal(mod.scale.value, 2.0)
         assert_equal(mod.scale.min, 0.0)
-        assert_equal(mod.scale.max, np.Inf)
+        assert_equal(mod.scale.max, np.inf)
         assert_equal(mod.scale.fixed, True)
         assert_equal(mod.background.display_name, 'background')
         assert_equal(str(mod.background.unit), 'dimensionless')
         assert_equal(mod.background.value, 1.0e-5)
         assert_equal(mod.background.min, 0.0)
-        assert_equal(mod.background.max, np.Inf)
+        assert_equal(mod.background.max, np.inf)
         assert_equal(mod.background.fixed, True)
         assert mod._resolution_function.smearing([1]) == 2.0
         assert mod._resolution_function.smearing([100]) == 2.0

--- a/tests/sample/elements/layers/test_layer.py
+++ b/tests/sample/elements/layers/test_layer.py
@@ -29,13 +29,13 @@ class TestLayer(unittest.TestCase):
         assert_equal(str(p.thickness.unit), 'Å')
         assert_equal(p.thickness.value, 10.0)
         assert_equal(p.thickness.min, 0.0)
-        assert_equal(p.thickness.max, np.Inf)
+        assert_equal(p.thickness.max, np.inf)
         assert_equal(p.thickness.fixed, True)
         assert_equal(p.roughness.display_name, 'roughness')
         assert_equal(str(p.roughness.unit), 'Å')
         assert_equal(p.roughness.value, 3.3)
         assert_equal(p.roughness.min, 0.0)
-        assert_equal(p.roughness.max, np.Inf)
+        assert_equal(p.roughness.max, np.inf)
         assert_equal(p.roughness.fixed, True)
 
     def test_shuffled_arguments(self):
@@ -48,13 +48,13 @@ class TestLayer(unittest.TestCase):
         assert_equal(str(p.thickness.unit), 'Å')
         assert_equal(p.thickness.value, 5.0)
         assert_equal(p.thickness.min, 0.0)
-        assert_equal(p.thickness.max, np.Inf)
+        assert_equal(p.thickness.max, np.inf)
         assert_equal(p.thickness.fixed, True)
         assert_equal(p.roughness.display_name, 'roughness')
         assert_equal(str(p.roughness.unit), 'Å')
         assert_equal(p.roughness.value, 2.0)
         assert_equal(p.roughness.min, 0.0)
-        assert_equal(p.roughness.max, np.Inf)
+        assert_equal(p.roughness.max, np.inf)
         assert_equal(p.roughness.fixed, True)
 
     def test_only_roughness_key(self):
@@ -63,7 +63,7 @@ class TestLayer(unittest.TestCase):
         assert_equal(str(p.roughness.unit), 'Å')
         assert_equal(p.roughness.value, 10.0)
         assert_equal(p.roughness.min, 0.0)
-        assert_equal(p.roughness.max, np.Inf)
+        assert_equal(p.roughness.max, np.inf)
         assert_equal(p.roughness.fixed, True)
 
     def test_only_roughness_key_paramter(self):
@@ -79,7 +79,7 @@ class TestLayer(unittest.TestCase):
         assert_equal(str(p.thickness.unit), 'Å')
         assert_equal(p.thickness.value, 10.0)
         assert_equal(p.thickness.min, 0.0)
-        assert_equal(p.thickness.max, np.Inf)
+        assert_equal(p.thickness.max, np.inf)
         assert_equal(p.thickness.fixed, True)
 
     def test_only_thickness_key_paramter(self):

--- a/tests/sample/elements/materials/test_material.py
+++ b/tests/sample/elements/materials/test_material.py
@@ -21,14 +21,14 @@ class TestMaterial:
         assert p.sld.display_name == 'sld'
         assert str(p.sld.unit) == '1/Å^2'
         assert p.sld.value == 4.186
-        assert p.sld.min == -np.Inf
-        assert p.sld.max == np.Inf
+        assert p.sld.min == -np.inf
+        assert p.sld.max == np.inf
         assert p.sld.fixed is True
         assert p.isld.display_name == 'isld'
         assert str(p.isld.unit) == '1/Å^2'
         assert p.isld.value == 0.0
-        assert p.isld.min == -np.Inf
-        assert p.isld.max == np.Inf
+        assert p.isld.min == -np.inf
+        assert p.isld.max == np.inf
         assert p.isld.fixed is True
 
     def test_shuffled_arguments(self):
@@ -38,14 +38,14 @@ class TestMaterial:
         assert p.sld.display_name == 'sld'
         assert str(p.sld.unit) == '1/Å^2'
         assert p.sld.value == 6.908
-        assert p.sld.min == -np.Inf
-        assert p.sld.max == np.Inf
+        assert p.sld.min == -np.inf
+        assert p.sld.max == np.inf
         assert p.sld.fixed is True
         assert p.isld.display_name == 'isld'
         assert str(p.isld.unit) == '1/Å^2'
         assert p.isld.value == -0.278
-        assert p.isld.min == -np.Inf
-        assert p.isld.max == np.Inf
+        assert p.isld.min == -np.inf
+        assert p.isld.max == np.inf
         assert p.isld.fixed is True
 
     def test_only_sld_key(self):
@@ -53,8 +53,8 @@ class TestMaterial:
         assert p.sld.display_name == 'sld'
         assert str(p.sld.unit) == '1/Å^2'
         assert p.sld.value == 10
-        assert p.sld.min == -np.Inf
-        assert p.sld.max == np.Inf
+        assert p.sld.min == -np.inf
+        assert p.sld.max == np.inf
         assert p.sld.fixed is True
 
     def test_only_sld_key_parameter(self):
@@ -69,8 +69,8 @@ class TestMaterial:
         assert p.isld.display_name == 'isld'
         assert str(p.isld.unit) == '1/Å^2'
         assert p.isld.value == 10
-        assert p.isld.min == -np.Inf
-        assert p.isld.max == np.Inf
+        assert p.isld.min == -np.inf
+        assert p.isld.max == np.inf
         assert p.isld.fixed is True
 
     def test_only_isld_key_parameter(self):

--- a/tests/sample/elements/materials/test_material_density.py
+++ b/tests/sample/elements/materials/test_material_density.py
@@ -16,7 +16,7 @@ class TestMaterialDensity(unittest.TestCase):
         assert str(p.density.unit) == 'kg/L'
         assert p.density.value == 2.33
         assert p.density.min == 0
-        assert p.density.max == np.Inf
+        assert p.density.max == np.inf
         assert p.density.fixed is True
 
     def test_default_constraint(self):

--- a/tests/sample/elements/materials/test_material_solvated.py
+++ b/tests/sample/elements/materials/test_material_solvated.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from easyscience import global_object
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 
 import easyreflectometry.sample.elements.materials.material_mixture
 import easyreflectometry.sample.elements.materials.material_solvated

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -10,7 +10,7 @@ PARAMETER_DETAILS = {
         'url': 'https://veryrealwebsite.com',
         'value': 1.0,
         'min': 0,
-        'max': np.Inf,
+        'max': np.inf,
         'fixed': True,
     },
     'test_parameter_10': {
@@ -36,7 +36,7 @@ def test_get_as_parameter():
     assert_equal(str(test_parameter.unit), 'dimensionless')
     assert_equal(test_parameter.value, 1.0)
     assert_equal(test_parameter.min, 0.0)
-    assert_equal(test_parameter.max, np.Inf)
+    assert_equal(test_parameter.max, np.inf)
     assert_equal(test_parameter.fixed, True)
     assert_equal(test_parameter.description, 'Test parameter')
 
@@ -96,7 +96,7 @@ def test_dict_remains_unchanged():
             'url': 'https://veryrealwebsite.com',
             'value': 1.0,
             'min': 0,
-            'max': np.Inf,
+            'max': np.inf,
             'fixed': True,
         }
     }

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import numpy as np
 from easyscience import global_object
 from easyscience.fitting import AvailableMinimizers
-from easyscience.Objects.new_variable import Parameter
+from easyscience.Objects.variable import Parameter
 from numpy.testing import assert_allclose
 
 import easyreflectometry


### PR DESCRIPTION
Update to use the branch of EasyScience where the old `Parameter` has been removed (`remove_old_parameter`). This includes upgrading to Numpy 2, removing Pint and updating Refl1d.